### PR TITLE
Improve navigation and launch resources hub

### DIFF
--- a/404.html
+++ b/404.html
@@ -15,6 +15,7 @@
   <meta name="twitter:description" content="Lock scope changes, clear approvals, and time-stamped PDFs. Same-day setup across Australia.">
   <link rel="preload" href="site-mobile.css?v=8" as="style" onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="site-mobile.css?v=8"></noscript>
+  <link rel="stylesheet" href="assets/site-nav.css?v=1">
   <link rel="icon" href="./favicon.ico">
   <link rel="apple-touch-icon" href="./apple-touch-icon.png">
   <meta name="theme-color" content="#000000">
@@ -85,129 +86,35 @@
   -->
 </head>
 <body>
-  <header class="site-header">
-    <div class="container nav-row">
-      <a class="brand" href="./index.html" aria-label="C2C Variations home">
-        <img class="icon" src="./assets/logo-icon.jpg" alt="C2C icon">
-      </a>
-      <button class="nav-hamburger" id="nav-hamburger" aria-label="Open navigation" aria-controls="main-nav" aria-expanded="false" tabindex="0">
-        <span class="nav-hamburger-bar"></span>
-        <span class="nav-hamburger-bar"></span>
-        <span class="nav-hamburger-bar"></span>
-      </button>
-      <nav class="nav" id="main-nav" role="navigation" aria-label="Main">
-        <a href="./index.html">Home</a>
-        <a href="./pricing.html">Pricing</a>
-        <a href="./about.html">About</a>
-        <a href="./docs.html">Docs</a>
-        <a class="btn btn-wa" href="https://wa.me/61466873332?text=Hi%20C2C%2C%20keen%20to%20get%20set%20up.&utm_source=site&utm_medium=button&utm_campaign=whatsapp" target="_blank" rel="noopener">WhatsApp</a>
-        <button id="c2c-chat-cta" class="c2c-chat-cta" aria-controls="c2c-chatbot-container" aria-expanded="false">💬 Chat with C2C</button>
-      </nav>
-  <style>
-    .nav-hamburger {
-      display: none;
-      flex-direction: column;
-      justify-content: center;
-      align-items: center;
-      width: 44px;
-      height: 44px;
-      background: none;
-      border: none;
-      cursor: pointer;
-      z-index: 100;
-      margin-left: 8px;
-    }
-    .nav-hamburger-bar {
-      width: 28px;
-      height: 4px;
-      background: #fff;
-      border-radius: 2px;
-      margin: 3px 0;
-      transition: all 0.3s;
-      display: block;
-    }
-    @media (max-width: 768px) {
-      .nav-hamburger { display: flex; }
-      .nav-row { gap: 8px; }
-      .nav {
-        position: absolute;
-        top: 64px;
-        right: 0;
-        left: 0;
-        background: rgba(0,0,0,0.98);
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 0;
-        padding: 0 0 12px 0;
-        box-shadow: 0 8px 24px rgba(0,0,0,0.18);
-        border-bottom: 1px solid var(--outline);
-        z-index: 99;
-        transform: translateY(-120%);
-        opacity: 0;
-        pointer-events: none;
-        transition: transform 0.25s, opacity 0.25s;
-      }
-      .nav.open {
-        transform: translateY(0);
-        opacity: 1;
-        pointer-events: auto;
-      }
-      .nav a, .nav .btn, .nav #c2c-chat-cta {
-        width: 100%;
-        text-align: left;
-        padding: 14px 24px;
-        border-radius: 0;
-        font-size: 1.1rem;
-        border: none;
-        background: none;
-        margin: 0;
-        box-shadow: none;
-      }
-      .nav .btn, .nav #c2c-chat-cta {
-        margin-top: 6px;
-      }
-    }
-  </style>
-  <script>
-    (function(){
-      var hamburger = document.getElementById('nav-hamburger');
-      var nav = document.getElementById('main-nav');
-      if (!hamburger || !nav) return;
-      hamburger.addEventListener('click', function(){
-        var open = nav.classList.toggle('open');
-        hamburger.setAttribute('aria-expanded', open);
-      });
-      nav.addEventListener('click', function(e){
-        if(e.target.tagName==='A'||e.target.classList.contains('btn')||e.target.id==='c2c-chat-cta'){
-          nav.classList.remove('open');
-          hamburger.setAttribute('aria-expanded','false');
-        }
-      });
-      document.addEventListener('click', function(e){
-        if(window.innerWidth>768) return;
-        if(!nav.classList.contains('open')) return;
-        if(!nav.contains(e.target) && e.target!==hamburger){
-          nav.classList.remove('open');
-          hamburger.setAttribute('aria-expanded','false');
-        }
-      });
-      window.addEventListener('resize', function(){
-        if(window.innerWidth>768){
-          nav.classList.remove('open');
-          hamburger.setAttribute('aria-expanded','false');
-        }
-      });
-    })();
-  </script>
-    </div>
-  </header>
+  <header class="site-header" data-nav-root>
+  <div class="container nav-row">
+    <a class="brand" href="./index.html" aria-label="C2C Variations home">
+      <img class="icon" src="./assets/logo-icon.jpg" alt="C2C icon">
+    </a>
+    <button class="nav-hamburger" type="button" data-nav-toggle aria-controls="main-nav" aria-expanded="false" aria-label="Open navigation">
+      <span class="nav-hamburger-bar"></span>
+      <span class="nav-hamburger-bar"></span>
+      <span class="nav-hamburger-bar"></span>
+    </button>
+    <nav class="nav site-nav" id="main-nav" role="navigation" aria-label="Main" data-nav-menu>
+      <a href="./index.html">Home</a>
+      <a href="./pricing.html">Pricing</a>
+      <a href="./about.html">About</a>
+      <a href="./docs.html">Docs</a>
+        <a href="./resources.html">Resources</a>
+      <a class="btn btn-wa" href="https://wa.me/61466873332?text=Hi%20C2C%2C%20keen%20to%20get%20set%20up.&utm_source=site&utm_medium=button&utm_campaign=whatsapp" target="_blank" rel="noopener">WhatsApp</a>
+      <button type="button" id="c2c-chat-cta" class="c2c-chat-cta" aria-controls="c2c-chatbot-container" aria-expanded="false">💬 Chat with C2C</button>
+    </nav>
+  </div>
+</header>
+
   <main class="container">
 <h1>404 — Page not found</h1><p class='muted'>Try a main page.</p><p><a class='btn btn-primary' href='./index.html'>Home</a></p>
   </main>
   <footer class="footer">
     <div class="container footer-links-row">
       <span>© C2C Variations</span>
-      <span class="footer-links"><a href="https://www.c2cvariations.com.au/pricing">See plans</a><a href="https://www.c2cvariations.com.au/about">About</a><a href="https://www.c2cvariations.com.au/testimonials">Testimonials</a><a href="https://www.c2cvariations.com.au/partners">Partners</a><a href="https://www.c2cvariations.com.au/privacy">Privacy</a><a href="https://www.c2cvariations.com.au/terms">Terms</a></span>
+      <span class="footer-links"><a href="https://www.c2cvariations.com.au/pricing">See plans</a><a href="https://www.c2cvariations.com.au/about">About</a><a href="https://www.c2cvariations.com.au/resources">Resources</a><a href="https://www.c2cvariations.com.au/testimonials">Testimonials</a><a href="https://www.c2cvariations.com.au/partners">Partners</a><a href="https://www.c2cvariations.com.au/privacy">Privacy</a><a href="https://www.c2cvariations.com.au/terms">Terms</a></span>
     </div>
   <style>
     @media (max-width: 600px) {
@@ -247,8 +154,8 @@
       </p>
     </div>
   </div>
+  <script src="assets/site-nav.js?v=1" defer></script>
   <script src="assets/chatbot.v6.js?v=1" defer></script>
-</script>
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/_worker.js
+++ b/_worker.js
@@ -7,64 +7,114 @@ export default {
     const css = `:root{--c2c-orange:#FF7A00}
 a[href^="https://buy.stripe.com"]{position:relative;z-index:9999;pointer-events:auto !important;-webkit-tap-highlight-color:transparent;touch-action:manipulation}
 .backdrop,.overlay,.modal-backdrop,.menu-backdrop,.click-shield{pointer-events:none !important}
-.nav-menu{display:none}.nav-menu.open{display:block}
-header[role="banner"].is-fixed+main{padding-top:72px}`;
+[data-nav-root]{position:sticky;top:0;background:rgba(0,0,0,0.9);border-bottom:1px solid rgba(255,255,255,0.12);backdrop-filter:blur(8px);z-index:60}
+[data-nav-root] .nav-row{display:flex;align-items:center;justify-content:space-between;gap:16px;position:relative}
+.nav-hamburger{display:none;flex-direction:column;justify-content:center;align-items:center;width:44px;height:44px;background:rgba(255,255,255,0.06);border:1px solid rgba(255,255,255,0.12);border-radius:10px;cursor:pointer;margin-left:8px;position:relative;z-index:101}
+.nav-hamburger-bar{width:26px;height:3px;background:#fff;border-radius:2px;margin:3px 0;transition:transform .2s ease,opacity .2s ease}
+[data-nav-menu],[data-nav-root] #main-nav{display:flex;align-items:center;gap:16px;margin-left:auto;flex-wrap:wrap}
+@media (max-width:768px){
+  .nav-hamburger{display:inline-flex}
+  [data-nav-menu],[data-nav-root] #main-nav{position:absolute;top:100%;right:0;left:0;background:rgba(0,0,0,0.98);flex-direction:column;align-items:stretch;gap:0;padding:8px 0 12px;box-shadow:0 20px 40px rgba(0,0,0,0.35);border-top:1px solid transparent;transform:translateY(-12px);opacity:0;visibility:hidden;pointer-events:none}
+  [data-nav-menu].open,[data-nav-root] #main-nav.open{transform:translateY(0);opacity:1;visibility:visible;pointer-events:auto;border-top-color:rgba(255,255,255,0.12)}
+  [data-nav-menu] a,[data-nav-menu] .btn,[data-nav-menu] #c2c-chat-cta,[data-nav-root] #main-nav a,[data-nav-root] #main-nav .btn,[data-nav-root] #main-nav #c2c-chat-cta{width:100%;text-align:left;padding:14px 24px;border-radius:0;margin:0;background:transparent;box-shadow:none}
+  [data-nav-menu] .btn,[data-nav-menu] #c2c-chat-cta,[data-nav-root] #main-nav .btn,[data-nav-root] #main-nav #c2c-chat-cta{margin-top:6px}
+}
+@media (prefers-reduced-motion:reduce){
+  .nav-hamburger,.nav-hamburger-bar,[data-nav-menu],[data-nav-root] #main-nav{transition:none !important}
+}`;
 
     const js = `(function(){
-  // MOBILE MENU (targets your ids first)
-  var hamburger = document.getElementById('nav-hamburger') 
-               || document.querySelector('[data-nav-toggle], .hamburger, .menu-toggle, #menu-toggle, button[aria-label="Menu"]');
-  var nav = document.getElementById('main-nav')
-         || document.querySelector('[data-nav], nav .nav-menu, #nav, #mobile-menu, .nav-menu');
+  function initNav(){
+    var toggle = document.querySelector('[data-nav-toggle]') || document.getElementById('nav-hamburger') || document.querySelector('.nav-hamburger');
+    var menu = document.querySelector('[data-nav-menu]') || document.getElementById('main-nav') || document.querySelector('.nav-menu, nav');
+    if(!toggle || !menu) return;
 
-  if (hamburger && nav) {
-    if(!nav.id) nav.id = 'c2c-nav';
-    hamburger.setAttribute('aria-controls', nav.id);
-    hamburger.addEventListener('click', function(e){
-      e.preventDefault(); e.stopPropagation();
-      var open = nav.classList.toggle('open');
-      hamburger.setAttribute('aria-expanded', open ? 'true' : 'false');
-    }, {passive:false});
+    var root = toggle.closest('[data-nav-root]') || toggle.closest('header') || document.body;
+    var labelOpen = toggle.getAttribute('aria-label') || toggle.getAttribute('data-nav-label-open') || 'Open navigation';
+    var labelClose = toggle.getAttribute('data-nav-label-close') || 'Close navigation';
+    if(!menu.id) menu.id = 'c2c-nav';
+    toggle.setAttribute('aria-controls', menu.id);
+    toggle.setAttribute('aria-expanded', 'false');
+    toggle.setAttribute('aria-label', labelOpen);
 
-    nav.addEventListener('click', function(e){
-      var t=e.target; 
-      if(t && (t.tagName==='A' || t.classList.contains('btn') || t.id==='c2c-chat-cta')){
-        nav.classList.remove('open'); hamburger.setAttribute('aria-expanded','false');
+    var isOpen = false;
+    function set(state){
+      if(isOpen === state) return;
+      isOpen = state;
+      menu.classList.toggle('open', state);
+      toggle.setAttribute('aria-expanded', state ? 'true' : 'false');
+      toggle.setAttribute('aria-label', state ? labelClose : labelOpen);
+    }
+
+    function close(){ set(false); }
+
+    toggle.addEventListener('click', function(e){
+      e.preventDefault();
+      e.stopPropagation();
+      set(!isOpen);
+    });
+
+    toggle.addEventListener('keydown', function(e){
+      if(e.key === 'Enter' || e.key === ' '){
+        e.preventDefault();
+        set(!isOpen);
       }
     });
 
-    document.addEventListener('click', function(e){
-      if (window.innerWidth>768) return;
-      if (!nav.classList.contains('open')) return;
-      if (!nav.contains(e.target) && e.target!==hamburger){
-        nav.classList.remove('open'); hamburger.setAttribute('aria-expanded','false');
-      }
+    menu.addEventListener('click', function(e){
+      var target = e.target && e.target.closest('a, button');
+      if(!target) return;
+      if(target.hasAttribute('data-nav-stay-open')) return;
+      close();
     });
+
+    document.addEventListener('pointerdown', function(e){
+      if(!isOpen) return;
+      if(root.contains(e.target)) return;
+      close();
+    });
+
+    document.addEventListener('focusin', function(e){
+      if(!isOpen) return;
+      if(root.contains(e.target)) return;
+      close();
+    });
+
+    document.addEventListener('keydown', function(e){
+      if(e.key === 'Escape') close();
+    });
+
+    var mq = window.matchMedia('(min-width: 769px)');
+    if(mq.addEventListener){
+      mq.addEventListener('change', function(ev){ if(ev.matches) close(); });
+    } else if(mq.addListener){
+      mq.addListener(function(ev){ if(ev.matches) close(); });
+    }
+
     window.addEventListener('resize', function(){
-      if (window.innerWidth>768){
-        nav.classList.remove('open'); hamburger.setAttribute('aria-expanded','false');
-      }
+      if(window.innerWidth > 768) close();
     });
   }
 
-  // STRIPE: handle <a>, <button>, data-href and inline onclick
+  if(document.readyState === 'loading'){
+    document.addEventListener('DOMContentLoaded', initNav, { once: true });
+  } else {
+    initNav();
+  }
+
   var STRIPE = 'https://buy.stripe.com';
   function go(href){ if(href) location.assign(href); }
 
   document.addEventListener('click', function(e){
-    // normal anchors
     var el = e.target.closest && e.target.closest('a[href^="'+STRIPE+'"]');
-    // buttons or custom elements
     if(!el) el = e.target.closest('[data-stripe],[data-href^="'+STRIPE+'"],[onclick*="buy.stripe.com"]');
-
     if(!el) return;
     e.preventDefault(); e.stopPropagation();
-
     var href = el.getAttribute && (el.getAttribute('href') || el.getAttribute('data-href') || el.getAttribute('data-stripe'));
     if(!href){
       var oc = el.getAttribute && el.getAttribute('onclick');
       if(oc){
-        var m = oc.match(/https?:\/\/buy\\.stripe\\.com[^'"]+/);
+        var m = oc.match(/https?:\\/\\/buy\\.stripe\\.com[^'"\s]+/);
         if(m) href = m[0];
       }
     }
@@ -72,16 +122,19 @@ header[role="banner"].is-fixed+main{padding-top:72px}`;
   }, true);
 
   document.addEventListener('keydown', function(e){
-    if(e.key!=='Enter' && e.key!==' ') return;
-    var el=document.activeElement;
+    if(e.key !== 'Enter' && e.key !== ' ') return;
+    var el = document.activeElement;
     if(!el) return;
-    var a=el.closest && (el.closest('a[href^="'+STRIPE+'"]') || el.closest('[data-stripe],[data-href^="'+STRIPE+'"],[onclick*="buy.stripe.com"]'));
-    if(!a) return;
+    var target = el.closest && (el.closest('a[href^="'+STRIPE+'"]') || el.closest('[data-stripe],[data-href^="'+STRIPE+'"],[onclick*="buy.stripe.com"]'));
+    if(!target) return;
     e.preventDefault(); e.stopPropagation();
-    var href=a.getAttribute('href')||a.getAttribute('data-href')||a.getAttribute('data-stripe');
+    var href = target.getAttribute('href') || target.getAttribute('data-href') || target.getAttribute('data-stripe');
     if(!href){
-      var oc=a.getAttribute('onclick'); 
-      if(oc){ var m=oc.match(/https?:\/\/buy\\.stripe\\.com[^'"]+/); if(m) href=m[0]; }
+      var oc = target.getAttribute('onclick');
+      if(oc){
+        var m = oc.match(/https?:\\/\\/buy\\.stripe\\.com[^'"\s]+/);
+        if(m) href = m[0];
+      }
     }
     go(href);
   }, true);

--- a/about.html
+++ b/about.html
@@ -15,6 +15,7 @@
   <meta name="twitter:description" content="Lock scope changes, clear approvals, and time-stamped PDFs. Same-day setup across Australia.">
   <link rel="preload" href="site-mobile.css?v=8" as="style" onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="site-mobile.css?v=8"></noscript>
+  <link rel="stylesheet" href="assets/site-nav.css?v=1">
   <style>
     :root{--bg:#000;--fg:#fff;--muted:#a7a7a7;--card:#0d0d0f;--line:#222;--accent:#ff8a3d;--wa:#25D366;}
     html{-webkit-text-size-adjust:100%;text-size-adjust:100%;}
@@ -38,120 +39,29 @@
   -->
 </head>
 <body>
-<header style="position:sticky;top:0;z-index:50;background:#000;border-bottom:1px solid #222;">
-  <div style="max-width:1100px;margin:0 auto;padding:14px 20px;display:flex;gap:16px;align-items:center;">
-    <a href="/" style="font-weight:800;color:#ff8a3d;text-decoration:none">Home</a>
-    <button class="nav-hamburger" id="nav-hamburger" aria-label="Open navigation" aria-controls="main-nav" aria-expanded="false" tabindex="0" style="margin-left:auto;">
+<header class="site-header" data-nav-root>
+  <div class="container nav-row">
+    <a class="brand" href="./index.html" aria-label="C2C Variations home">
+      <img class="icon" src="./assets/logo-icon.jpg" alt="C2C icon">
+    </a>
+    <button class="nav-hamburger" type="button" data-nav-toggle aria-controls="main-nav" aria-expanded="false" aria-label="Open navigation">
       <span class="nav-hamburger-bar"></span>
       <span class="nav-hamburger-bar"></span>
       <span class="nav-hamburger-bar"></span>
     </button>
-    <nav id="main-nav" style="display:flex;gap:16px;margin-left:auto" role="navigation" aria-label="Main">
-      <a href="/pricing" style="color:#ff8a3d;text-decoration:none">Pricing</a>
-      <a href="/docs" style="color:#ff8a3d;text-decoration:none">Docs</a>
-      <a href="/about" style="color:#ff8a3d;text-decoration:none">About</a>
-      <a href="/privacy" style="color:#ff8a3d;text-decoration:none">Privacy</a>
-      <a href="/terms" style="color:#ff8a3d;text-decoration:none">Terms</a>
+    <nav class="nav site-nav" id="main-nav" role="navigation" aria-label="Main" data-nav-menu>
+      <a href="./index.html">Home</a>
+      <a href="./pricing.html">Pricing</a>
+      <a href="./about.html" aria-current="page">About</a>
+      <a href="./docs.html">Docs</a>
+        <a href="./resources.html">Resources</a>
+      <a href="./privacy.html">Privacy</a>
+      <a href="./terms.html">Terms</a>
       <a class="btn btn-wa" href="https://wa.me/61466873332?text=Hi%20C2C%2C%20keen%20to%20get%20set%20up.&utm_source=site&utm_medium=button&utm_campaign=whatsapp" target="_blank" rel="noopener">WhatsApp</a>
-      <button id="c2c-chat-cta" class="c2c-chat-cta" aria-controls="c2c-chatbot-container" aria-expanded="false">💬 Chat with C2C</button>
+      <button type="button" id="c2c-chat-cta" class="c2c-chat-cta" aria-controls="c2c-chatbot-container" aria-expanded="false">💬 Chat with C2C</button>
     </nav>
   </div>
 </header>
-  <style>
-    .nav-hamburger {
-      display: none;
-      flex-direction: column;
-      justify-content: center;
-      align-items: center;
-      width: 44px;
-      height: 44px;
-      background: none;
-      border: none;
-      cursor: pointer;
-      z-index: 100;
-      margin-left: 8px;
-    }
-    .nav-hamburger-bar {
-      width: 28px;
-      height: 4px;
-      background: #fff;
-      border-radius: 2px;
-      margin: 3px 0;
-      transition: all 0.3s;
-      display: block;
-    }
-    @media (max-width: 768px) {
-      .nav-hamburger { display: flex !important; }
-      #main-nav {
-        position: absolute;
-        top: 64px;
-        right: 0;
-        left: 0;
-        background: rgba(0,0,0,0.98);
-        flex-direction: column !important;
-        align-items: flex-start !important;
-        gap: 0 !important;
-        padding: 0 0 12px 0 !important;
-        box-shadow: 0 8px 24px rgba(0,0,0,0.18);
-        border-bottom: 1px solid #222;
-        z-index: 99;
-        transform: translateY(-120%);
-        opacity: 0;
-        pointer-events: none;
-        transition: transform 0.25s, opacity 0.25s;
-      }
-      #main-nav.open {
-        transform: translateY(0);
-        opacity: 1;
-        pointer-events: auto;
-      }
-      #main-nav a, #main-nav .btn, #main-nav #c2c-chat-cta {
-        width: 100%;
-        text-align: left;
-        padding: 14px 24px;
-        border-radius: 0;
-        font-size: 1.1rem;
-        border: none;
-        background: none;
-        margin: 0;
-        box-shadow: none;
-      }
-      #main-nav .btn, #main-nav #c2c-chat-cta {
-        margin-top: 6px;
-      }
-    }
-  </style>
-  <script>
-    (function(){
-      var hamburger = document.getElementById('nav-hamburger');
-      var nav = document.getElementById('main-nav');
-      if (!hamburger || !nav) return;
-      hamburger.addEventListener('click', function(){
-        var open = nav.classList.toggle('open');
-        hamburger.setAttribute('aria-expanded', open);
-      });
-      nav.addEventListener('click', function(e){
-        if(e.target.tagName==='A'||e.target.classList.contains('btn')||e.target.id==='c2c-chat-cta'){
-          nav.classList.remove('open');
-          hamburger.setAttribute('aria-expanded','false');
-        }
-      });
-      document.addEventListener('click', function(e){
-        if(window.innerWidth>768) return;
-        if(!nav.classList.contains('open')) return;
-        if(!nav.contains(e.target) && e.target!==hamburger){
-          nav.classList.remove('open');
-          hamburger.setAttribute('aria-expanded','false');
-        }
-      });
-      window.addEventListener('resize', function(){
-        if(window.innerWidth>768){
-          nav.classList.remove('open');
-          hamburger.setAttribute('aria-expanded','false');
-        }
-      });
-    })();
-  </script>
 
 <h1>About C2C Variations</h1>
 <p class="muted"><strong>Docs done. Jobs won.</strong> Built in Australia for Aussie trades. We turn the messy back‑and‑forth around <em>variations, quotes, SWMS and agreements</em> into fast, signed paperwork — straight from WhatsApp.</p>
@@ -205,7 +115,7 @@
     </div>
       <div class="container footer-links-row">
         <span>© C2C Variations</span>
-        <span class="footer-links"><a href="https://www.c2cvariations.com.au/pricing">See plans</a><a href="https://www.c2cvariations.com.au/about">About</a><a href="https://www.c2cvariations.com.au/testimonials">Testimonials</a><a href="https://www.c2cvariations.com.au/partners">Partners</a><a href="https://www.c2cvariations.com.au/privacy">Privacy</a><a href="https://www.c2cvariations.com.au/terms">Terms</a></span>
+        <span class="footer-links"><a href="https://www.c2cvariations.com.au/pricing">See plans</a><a href="https://www.c2cvariations.com.au/about">About</a><a href="https://www.c2cvariations.com.au/resources">Resources</a><a href="https://www.c2cvariations.com.au/testimonials">Testimonials</a><a href="https://www.c2cvariations.com.au/partners">Partners</a><a href="https://www.c2cvariations.com.au/privacy">Privacy</a><a href="https://www.c2cvariations.com.au/terms">Terms</a></span>
       </div>
     <style>
       @media (max-width: 600px) {
@@ -230,8 +140,8 @@
       }
     </style>
   </footer>
+  <script src="assets/site-nav.js?v=1" defer></script>
   <script src="assets/chatbot.v6.js?v=1" defer></script>
-</script>
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/assets/site-nav.css
+++ b/assets/site-nav.css
@@ -1,0 +1,151 @@
+/* Shared site header navigation styles (v1) */
+[data-nav-root] {
+  position: sticky;
+  top: 0;
+  z-index: 60;
+  background: rgba(0, 0, 0, 0.9);
+  border-bottom: 1px solid var(--outline, rgba(255, 255, 255, 0.12));
+  backdrop-filter: blur(8px);
+}
+
+[data-nav-root] .nav-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  position: relative;
+}
+
+[data-nav-root] .brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  text-decoration: none;
+  color: inherit;
+}
+
+[data-nav-root] .brand img {
+  width: 56px;
+  height: 56px;
+  border-radius: 12px;
+  display: block;
+}
+
+.nav-hamburger {
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 44px;
+  height: 44px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  cursor: pointer;
+  margin-left: 8px;
+  transition: background 0.2s ease;
+  position: relative;
+  z-index: 101;
+}
+
+.nav-hamburger:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.4);
+  outline-offset: 2px;
+}
+
+.nav-hamburger-bar {
+  width: 26px;
+  height: 3px;
+  background: #fff;
+  border-radius: 2px;
+  margin: 3px 0;
+  display: block;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+[data-nav-menu] {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-left: auto;
+  flex-wrap: wrap;
+}
+
+[data-nav-menu] a {
+  color: inherit;
+  text-decoration: none;
+  opacity: 0.9;
+}
+
+[data-nav-menu] a:hover,
+[data-nav-menu] a:focus-visible {
+  opacity: 1;
+}
+
+@media (max-width: 900px) {
+  [data-nav-root] .brand img {
+    width: 48px;
+    height: 48px;
+  }
+}
+
+@media (max-width: 768px) {
+  .nav-hamburger {
+    display: inline-flex;
+    background: rgba(255, 255, 255, 0.06);
+    border-color: rgba(255, 255, 255, 0.08);
+  }
+
+  [data-nav-menu] {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    left: 0;
+    background: rgba(0, 0, 0, 0.98);
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0;
+    padding: 8px 0 12px;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
+    border-top: 1px solid transparent;
+    transform: translateY(-12px);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+  }
+
+  [data-nav-menu].open {
+    transform: translateY(0);
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+    border-top-color: var(--outline, rgba(255, 255, 255, 0.12));
+  }
+
+  [data-nav-menu] a,
+  [data-nav-menu] .btn,
+  [data-nav-menu] #c2c-chat-cta {
+    width: 100%;
+    text-align: left;
+    padding: 14px 24px;
+    border-radius: 0;
+    font-size: 1.05rem;
+    border: none;
+    background: transparent;
+    margin: 0;
+    box-shadow: none;
+  }
+
+  [data-nav-menu] .btn,
+  [data-nav-menu] #c2c-chat-cta {
+    margin-top: 6px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nav-hamburger,
+  .nav-hamburger-bar,
+  [data-nav-menu] {
+    transition: none !important;
+  }
+}

--- a/assets/site-nav.js
+++ b/assets/site-nav.js
@@ -1,0 +1,97 @@
+(function(){
+  var ROOT_ATTR = 'data-nav-root';
+  var TOGGLE_ATTR = 'data-nav-toggle';
+  var MENU_ATTR = 'data-nav-menu';
+  var OPEN_CLASS = 'open';
+  var BREAKPOINT = 768;
+  var media = window.matchMedia('(min-width: ' + (BREAKPOINT + 1) + 'px)');
+
+  function ready(fn){
+    if(document.readyState === 'loading'){
+      document.addEventListener('DOMContentLoaded', fn, { once: true });
+    } else {
+      fn();
+    }
+  }
+
+  function initNav(root){
+    var toggle = root.querySelector('[' + TOGGLE_ATTR + ']');
+    var menu = root.querySelector('[' + MENU_ATTR + ']');
+    if(!toggle || !menu) return;
+
+    var labelOpen = toggle.getAttribute('aria-label') || toggle.getAttribute('data-nav-label-open') || 'Open navigation';
+    var labelClose = toggle.getAttribute('data-nav-label-close') || 'Close navigation';
+    var isOpen = false;
+
+    toggle.setAttribute('aria-expanded', 'false');
+    toggle.setAttribute('aria-label', labelOpen);
+
+    function setOpen(next){
+      if(isOpen === next) return;
+      isOpen = next;
+      menu.classList.toggle(OPEN_CLASS, next);
+      toggle.setAttribute('aria-expanded', next ? 'true' : 'false');
+      toggle.setAttribute('aria-label', next ? labelClose : labelOpen);
+    }
+
+    function onToggle(event){
+      event.preventDefault();
+      event.stopPropagation();
+      setOpen(!isOpen);
+    }
+
+    function onOutside(event){
+      if(!isOpen) return;
+      if(root.contains(event.target)) return;
+      setOpen(false);
+    }
+
+    function onKey(event){
+      if(event.key === 'Escape' && isOpen){
+        setOpen(false);
+      }
+    }
+
+    function onNavActivate(event){
+      var interactive = event.target.closest('a, button');
+      if(!interactive) return;
+      if(!menu.contains(interactive)) return;
+      if(interactive.hasAttribute('data-nav-stay-open')) return;
+      setOpen(false);
+    }
+
+    function onResize(){
+      if(window.innerWidth > BREAKPOINT){
+        setOpen(false);
+      }
+    }
+
+    toggle.addEventListener('click', onToggle);
+    toggle.addEventListener('keydown', function(event){
+      if(event.key === 'Enter' || event.key === ' '){
+        event.preventDefault();
+        onToggle(event);
+      }
+    });
+
+    menu.addEventListener('click', onNavActivate);
+    document.addEventListener('pointerdown', onOutside);
+    document.addEventListener('focusin', function(event){
+      if(!isOpen) return;
+      if(root.contains(event.target)) return;
+      setOpen(false);
+    });
+    document.addEventListener('keydown', onKey);
+
+    media.addEventListener('change', function(e){
+      if(e.matches){
+        setOpen(false);
+      }
+    });
+    window.addEventListener('resize', onResize);
+  }
+
+  ready(function(){
+    document.querySelectorAll('[' + ROOT_ATTR + ']').forEach(initNav);
+  });
+})();

--- a/assets/stripe-links.js
+++ b/assets/stripe-links.js
@@ -1,0 +1,45 @@
+(function(){
+  var STRIPE_ORIGIN = 'https://buy.stripe.com';
+
+  function resolveStripeHref(el){
+    if(!el) return '';
+    var href = el.getAttribute && (el.getAttribute('href') || el.getAttribute('data-href') || el.getAttribute('data-stripe'));
+    if(!href){
+      var onclick = el.getAttribute && el.getAttribute('onclick');
+      if(onclick){
+        var match = onclick.match(/https?:\/\/buy\.stripe\.com[^'"\s]+/);
+        if(match) href = match[0];
+      }
+    }
+    return href || '';
+  }
+
+  function navigate(href){
+    if(href && href.indexOf(STRIPE_ORIGIN) === 0){
+      window.location.assign(href);
+    }
+  }
+
+  document.addEventListener('click', function(event){
+    var target = event.target.closest && event.target.closest('a[href^="'+STRIPE_ORIGIN+'"],[data-stripe],[data-href^="'+STRIPE_ORIGIN+'"],[onclick*="buy.stripe.com"]');
+    if(!target) return;
+    var href = resolveStripeHref(target);
+    if(!href) return;
+    event.preventDefault();
+    event.stopPropagation();
+    navigate(href);
+  }, true);
+
+  document.addEventListener('keydown', function(event){
+    if(event.key !== 'Enter' && event.key !== ' ') return;
+    var active = document.activeElement;
+    if(!active) return;
+    var trigger = active.closest && active.closest('a[href^="'+STRIPE_ORIGIN+'"],[data-stripe],[data-href^="'+STRIPE_ORIGIN+'"],[onclick*="buy.stripe.com"]');
+    if(!trigger) return;
+    var href = resolveStripeHref(trigger);
+    if(!href) return;
+    event.preventDefault();
+    event.stopPropagation();
+    navigate(href);
+  }, true);
+})();

--- a/docs.html
+++ b/docs.html
@@ -17,6 +17,7 @@
 <meta name="twitter:description" content="Lock scope changes, clear approvals, and time-stamped PDFs. Same-day setup across Australia.">
 <link rel="preload" href="site-mobile.css?v=8" as="style" onload="this.onload=null;this.rel='stylesheet'">
 <noscript><link rel="stylesheet" href="site-mobile.css?v=8"></noscript>
+<link rel="stylesheet" href="assets/site-nav.css?v=1">
 <style>
     :root{--bg:#000;--fg:#fff;--muted:#a7a7a7;--card:#0d0d0f;--line:#222;--accent:#ff8a3d;--wa:#25D366;}
     html{-webkit-text-size-adjust:100%;text-size-adjust:100%;}
@@ -47,120 +48,28 @@
   -->
 </head>
 <body>
-<header style="position:sticky;top:0;z-index:50;background:#000;border-bottom:1px solid #222;">
-<div style="max-width:1100px;margin:0 auto;padding:14px 20px;display:flex;gap:16px;align-items:center;">
-<a href="/" style="font-weight:800;color:#ff8a3d;text-decoration:none">Home</a>
-<button class="nav-hamburger" id="nav-hamburger" aria-label="Open navigation" aria-controls="main-nav" aria-expanded="false" tabindex="0" style="margin-left:auto;">
-  <span class="nav-hamburger-bar"></span>
-  <span class="nav-hamburger-bar"></span>
-  <span class="nav-hamburger-bar"></span>
-</button>
-<nav id="main-nav" style="display:flex;gap:16px;margin-left:auto" role="navigation" aria-label="Main">
-<a href="/pricing" style="color:#ff8a3d;text-decoration:none">Pricing</a>
-<a href="/docs" style="color:#ff8a3d;text-decoration:none">Docs</a>
-<a href="/about" style="color:#ff8a3d;text-decoration:none">About</a>
-<a href="/privacy" style="color:#ff8a3d;text-decoration:none">Privacy</a>
-<a href="/terms" style="color:#ff8a3d;text-decoration:none">Terms</a>
-<a class="btn btn-wa" href="https://wa.me/61466873332?text=Hi%20C2C%2C%20keen%20to%20get%20set%20up.&utm_source=site&utm_medium=button&utm_campaign=whatsapp" target="_blank" rel="noopener">WhatsApp</a>
-  <button id="c2c-chat-cta" class="c2c-chat-cta" aria-controls="c2c-chatbot-container" aria-expanded="false">💬 Chat with C2C</button>
-</nav>
-</div>
-  <style>
-    .nav-hamburger {
-      display: none;
-      flex-direction: column;
-      justify-content: center;
-      align-items: center;
-      width: 44px;
-      height: 44px;
-      background: none;
-      border: none;
-      cursor: pointer;
-      z-index: 100;
-      margin-left: 8px;
-    }
-    .nav-hamburger-bar {
-      width: 28px;
-      height: 4px;
-      background: #fff;
-      border-radius: 2px;
-      margin: 3px 0;
-      transition: all 0.3s;
-      display: block;
-    }
-    @media (max-width: 768px) {
-      .nav-hamburger { display: flex !important; }
-      #main-nav {
-        position: absolute;
-        top: 64px;
-        right: 0;
-        left: 0;
-        background: rgba(0,0,0,0.98);
-        flex-direction: column !important;
-        align-items: flex-start !important;
-        gap: 0 !important;
-        padding: 0 0 12px 0 !important;
-        box-shadow: 0 8px 24px rgba(0,0,0,0.18);
-        border-bottom: 1px solid #222;
-        z-index: 99;
-        transform: translateY(-120%);
-        opacity: 0;
-        pointer-events: none;
-        transition: transform 0.25s, opacity 0.25s;
-      }
-      #main-nav.open {
-        transform: translateY(0);
-        opacity: 1;
-        pointer-events: auto;
-      }
-      #main-nav a, #main-nav .btn, #main-nav #c2c-chat-cta {
-        width: 100%;
-        text-align: left;
-        padding: 14px 24px;
-        border-radius: 0;
-        font-size: 1.1rem;
-        border: none;
-        background: none;
-        margin: 0;
-        box-shadow: none;
-      }
-      #main-nav .btn, #main-nav #c2c-chat-cta {
-        margin-top: 6px;
-      }
-    }
-  </style>
-  <script>
-    (function(){
-      var hamburger = document.getElementById('nav-hamburger');
-      var nav = document.getElementById('main-nav');
-      if (!hamburger || !nav) return;
-      hamburger.addEventListener('click', function(){
-        var open = nav.classList.toggle('open');
-        hamburger.setAttribute('aria-expanded', open);
-      });
-      nav.addEventListener('click', function(e){
-        if(e.target.tagName==='A'||e.target.classList.contains('btn')||e.target.id==='c2c-chat-cta'){
-          nav.classList.remove('open');
-          hamburger.setAttribute('aria-expanded','false');
-        }
-      });
-      document.addEventListener('click', function(e){
-        if(window.innerWidth>768) return;
-        if(!nav.classList.contains('open')) return;
-        if(!nav.contains(e.target) && e.target!==hamburger){
-          nav.classList.remove('open');
-          hamburger.setAttribute('aria-expanded','false');
-        }
-      });
-      window.addEventListener('resize', function(){
-        if(window.innerWidth>768){
-          nav.classList.remove('open');
-          hamburger.setAttribute('aria-expanded','false');
-        }
-      });
-    })();
-  </script>
+<header class="site-header" data-nav-root>
+  <div class="container nav-row">
+    <a class="brand" href="./index.html" aria-label="C2C Variations home">
+      <img class="icon" src="./assets/logo-icon.jpg" alt="C2C icon">
+    </a>
+    <button class="nav-hamburger" type="button" data-nav-toggle aria-controls="main-nav" aria-expanded="false" aria-label="Open navigation">
+      <span class="nav-hamburger-bar"></span>
+      <span class="nav-hamburger-bar"></span>
+      <span class="nav-hamburger-bar"></span>
+    </button>
+    <nav class="nav site-nav" id="main-nav" role="navigation" aria-label="Main" data-nav-menu>
+      <a href="./index.html">Home</a>
+      <a href="./pricing.html">Pricing</a>
+      <a href="./about.html">About</a>
+      <a href="./docs.html" aria-current="page">Docs</a>
+        <a href="./resources.html">Resources</a>
+      <a class="btn btn-wa" href="https://wa.me/61466873332?text=Hi%20C2C%2C%20keen%20to%20get%20set%20up.&utm_source=site&utm_medium=button&utm_campaign=whatsapp" target="_blank" rel="noopener">WhatsApp</a>
+      <button type="button" id="c2c-chat-cta" class="c2c-chat-cta" aria-controls="c2c-chatbot-container" aria-expanded="false">💬 Chat with C2C</button>
+    </nav>
+  </div>
 </header>
+
 <div class="wrap">
 <h1>Docs Hub</h1>
 <p class="muted">Tap a group to open. WhatsApp-first today — generators later.</p>
@@ -262,7 +171,7 @@
   <footer class="footer">
     <div class="container footer-links-row">
       <span>© C2C Variations</span>
-      <span class="footer-links"><a href="https://www.c2cvariations.com.au/pricing">See plans</a><a href="https://www.c2cvariations.com.au/about">About</a><a href="https://www.c2cvariations.com.au/testimonials">Testimonials</a><a href="https://www.c2cvariations.com.au/partners">Partners</a><a href="https://www.c2cvariations.com.au/privacy">Privacy</a><a href="https://www.c2cvariations.com.au/terms">Terms</a></span>
+      <span class="footer-links"><a href="https://www.c2cvariations.com.au/pricing">See plans</a><a href="https://www.c2cvariations.com.au/about">About</a><a href="https://www.c2cvariations.com.au/resources">Resources</a><a href="https://www.c2cvariations.com.au/testimonials">Testimonials</a><a href="https://www.c2cvariations.com.au/partners">Partners</a><a href="https://www.c2cvariations.com.au/privacy">Privacy</a><a href="https://www.c2cvariations.com.au/terms">Terms</a></span>
     </div>
   <style>
     @media (max-width: 600px) {
@@ -287,8 +196,8 @@
     }
   </style>
   </footer>
+  <script src="assets/site-nav.js?v=1" defer></script>
   <script src="assets/chatbot.v6.js?v=1" defer></script>
-</script>
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/index (1).html
+++ b/index (1).html
@@ -10,6 +10,7 @@
   <link rel="canonical" href="https://www.c2cvariations.com.au/">
   <link rel="preload" href="site-mobile.css?v=8" as="style" onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="site-mobile.css?v=8"></noscript>
+  <link rel="stylesheet" href="assets/site-nav.css?v=1">
   <link rel="stylesheet" href="assets/nav-cta.hotfix.css?v=9">
   <link rel="stylesheet" href="assets/chatbot.v6.css?v=1">
   <style>
@@ -67,42 +68,38 @@
     .footer{padding:30px 0;color:#a7a7a7;border-top:1px solid var(--outline);margin-top:34px}
     .footer a{color:#ff8a3d;text-decoration:none}
     /* mobile menu */
-    .nav-hamburger{display:none;flex-direction:column;justify-content:center;align-items:center;width:44px;height:44px;background:none;border:none;cursor:pointer;z-index:100;margin-left:8px}
-    .nav-hamburger-bar{width:28px;height:4px;background:#fff;border-radius:2px;margin:3px 0;transition:all .3s;display:block}
-    @media (max-width: 768px){
-      .nav-hamburger{display:flex}
-      .nav-row{gap:8px}
-      .nav{position:absolute;top:64px;right:0;left:0;background:rgba(0,0,0,.98);flex-direction:column;align-items:flex-start;gap:0;padding:0 0 12px;border-bottom:1px solid var(--outline);z-index:99;transform:translateY(-120%);opacity:0;pointer-events:none;transition:transform .25s,opacity .25s}
-      .nav.open{transform:translateY(0);opacity:1;pointer-events:auto}
-      .nav a,.nav .btn,.nav #c2c-chat-cta{width:100%;text-align:left;padding:14px 24px;border-radius:0;font-size:1.1rem;border:none;background:none;margin:0;box-shadow:none}
-      .nav .btn,.nav #c2c-chat-cta{margin-top:6px}
-    }
+    
+    
+    
     /* ensure anchors & overlays behave */
     a[href^='https://buy.stripe.com']{position:relative;z-index:9999;pointer-events:auto !important;-webkit-tap-highlight-color:transparent;touch-action:manipulation}
     .backdrop,.overlay,.modal-backdrop,.menu-backdrop,.click-shield{pointer-events:none !important}
   </style>
 </head>
 <body>
-<header class="site-header" role="banner">
+<header class="site-header" data-nav-root>
   <div class="container nav-row">
     <a class="brand" href="./index.html" aria-label="C2C Variations home">
       <img class="icon" src="./assets/logo-icon.jpg" alt="C2C icon">
     </a>
-    <nav class="nav" id="main-nav" role="navigation" aria-label="Main">
-      <a href="./index.html" aria-current="page">Home</a>
+    <button class="nav-hamburger" type="button" data-nav-toggle aria-controls="main-nav" aria-expanded="false" aria-label="Open navigation">
+      <span class="nav-hamburger-bar"></span>
+      <span class="nav-hamburger-bar"></span>
+      <span class="nav-hamburger-bar"></span>
+    </button>
+    <nav class="nav site-nav" id="main-nav" role="navigation" aria-label="Main" data-nav-menu>
+      <a href="./index.html">Home</a>
       <a href="./pricing.html">Pricing</a>
       <a href="./about.html">About</a>
       <a href="./docs.html">Docs</a>
+        <a href="./resources.html">Resources</a>
       <a class="btn btn-wa" href="https://wa.me/61466873332?text=Hi%20C2C%2C%20keen%20to%20get%20set%20up.&utm_source=site&utm_medium=button&utm_campaign=whatsapp" target="_blank" rel="noopener">WhatsApp</a>
-      <button id="c2c-chat-cta" class="c2c-chat-cta" aria-controls="c2c-chatbot-container" aria-expanded="false">💬 Chat with C2C</button>
+      <button type="button" id="c2c-chat-cta" class="c2c-chat-cta" aria-controls="c2c-chatbot-container" aria-expanded="false">💬 Chat with C2C</button>
     </nav>
   </div>
-  <button class="nav-hamburger" id="nav-hamburger" aria-label="Open navigation" aria-controls="main-nav" aria-expanded="false">
-    <span class="nav-hamburger-bar"></span>
-    <span class="nav-hamburger-bar"></span>
-    <span class="nav-hamburger-bar"></span>
-  </button>
 </header>
+
+
 
 <main class="container">
   <div class="ticker"><div class="ticker-viewport">
@@ -155,7 +152,7 @@
 <footer class="footer">
   <div class="container footer-links-row" style="display:flex;gap:14px;align-items:center;justify-content:space-between;flex-wrap:wrap">
     <span>© C2C Variations</span>
-    <span class="footer-links"><a href="./pricing.html">See plans</a><a href="./about.html">About</a><a href="./testimonials.html">Testimonials</a><a href="./partners.html">Partners</a><a href="./privacy.html">Privacy</a><a href="./terms.html">Terms</a></span>
+    <span class="footer-links"><a href="./pricing.html">See plans</a><a href="./about.html">About</a><a href="./resources.html">Resources</a><a href="./testimonials.html">Testimonials</a><a href="./partners.html">Partners</a><a href="./privacy.html">Privacy</a><a href="./terms.html">Terms</a></span>
   </div>
 </footer>
 
@@ -187,40 +184,10 @@ document.addEventListener('click',function(e){
     </p>
   </div>
 </div>
-<script src="assets/chatbot.v6.js?v=1" defer></script>
+<script src="assets/site-nav.js?v=1" defer></script>
+  <script src="assets/chatbot.v6.js?v=1" defer></script>
 
 <!-- Final, robust hamburger + Stripe link enforcement -->
-<script>
-(function(){
-  var hamburger=document.getElementById('nav-hamburger');
-  var nav=document.getElementById('main-nav');
-  if(hamburger&&nav){
-    hamburger.addEventListener('click',function(e){
-      e.stopPropagation();
-      var open=nav.classList.toggle('open');
-      hamburger.setAttribute('aria-expanded',open?'true':'false');
-    });
-    nav.addEventListener('click',function(e){
-      if(e.target.tagName==='A'||e.target.classList.contains('btn')||e.target.id==='c2c-chat-cta'){
-        nav.classList.remove('open'); hamburger.setAttribute('aria-expanded','false');
-      }
-    });
-    document.addEventListener('click',function(e){
-      if(window.innerWidth>768) return;
-      if(!nav.classList.contains('open')) return;
-      if(!nav.contains(e.target) && e.target!==hamburger){
-        nav.classList.remove('open'); hamburger.setAttribute('aria-expanded','false');
-      }
-    });
-    window.addEventListener('resize',function(){
-      if(window.innerWidth>768){ nav.classList.remove('open'); hamburger.setAttribute('aria-expanded','false'); }
-    });
-  }
-  // Defensive: if any overlay exists, disable pointer events
-  var style=document.createElement('style');
-  style.textContent='.backdrop,.overlay,.modal-backdrop,.menu-backdrop,.click-shield{pointer-events:none !important}';
-  document.head.appendChild(style);
-})();
-</script>
+
 </body>
 </html>

--- a/index.homefix.html
+++ b/index.homefix.html
@@ -6,6 +6,7 @@
 <title>C2C Variations — Docs done. Jobs won.</title>
 <link rel="icon" href="./favicon.ico">
 <link rel="apple-touch-icon" href="./apple-touch-icon.png">
+<link rel="stylesheet" href="assets/site-nav.css?v=1">
 <style>
 :root{--bg:#000;--card:#0b0b0b;--muted:#c9c9c9;--text:#fff;--orange:#ff7a00;--outline:#222;--wa:#25D366}
 *{box-sizing:border-box}html,body{margin:0;padding:0}body{font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial;background:#000;color:#fff}
@@ -26,15 +27,9 @@ h1{margin:12px 0 8px;font-size:52px}.hero{font-size:1.2rem;color:#e9e9e9}
 .card{background:var(--card);border-radius:16px;padding:18px;border:1px solid var(--outline)}
 .pill{display:inline-block;background:#111;border:1px solid #222;padding:4px 10px;border-radius:999px;font-size:.8rem;color:#cfcfcf;margin-bottom:8px}
 /* MOBILE MENU */
-.nav-hamburger{display:none;flex-direction:column;justify-content:center;align-items:center;width:44px;height:44px;background:none;border:1px solid #222;border-radius:10px;cursor:pointer;margin-left:8px}
-.nav-hamburger-bar{width:28px;height:4px;background:#fff;border-radius:2px;margin:3px 0;display:block}
-@media (max-width: 768px){
-  .nav-hamburger{display:flex}
-  .nav-row{gap:8px}
-  .nav{position:absolute;top:64px;right:0;left:0;background:rgba(0,0,0,.98);flex-direction:column;align-items:flex-start;gap:0;padding:0 0 12px;border-bottom:1px solid var(--outline);z-index:99;transform:translateY(-120%);opacity:0;pointer-events:none;transition:transform .25s,opacity .25s}
-  .nav.open{transform:translateY(0);opacity:1;pointer-events:auto}
-  .nav a,.nav .btn{width:100%;text-align:left;padding:14px 24px;border-radius:0;font-size:1.05rem;border:none;background:none;margin:0;box-shadow:none}
-}
+
+
+
 /* kill any foreign overlays */
 .backdrop,.overlay,.modal-backdrop,.menu-backdrop,.click-shield{pointer-events:none !important}
 /* completely hide the ticker/strip */
@@ -42,22 +37,29 @@ h1{margin:12px 0 8px;font-size:52px}.hero{font-size:1.2rem;color:#e9e9e9}
 </style>
 </head>
 <body>
-<header class="site-header">
+<header class="site-header" data-nav-root>
   <div class="container nav-row">
-    <a class="brand" href="./index.html"><img src="./assets/logo-icon.jpg" alt="C2C icon"></a>
-    <!-- ONLY ONE NAV — this is the mobile/desktop nav -->
-    <nav class="nav" id="main-nav" aria-label="Main">
-      <a href="./index.html" aria-current="page">Home</a>
+    <a class="brand" href="./index.html" aria-label="C2C Variations home">
+      <img class="icon" src="./assets/logo-icon.jpg" alt="C2C icon">
+    </a>
+    <button class="nav-hamburger" type="button" data-nav-toggle aria-controls="main-nav" aria-expanded="false" aria-label="Open navigation">
+      <span class="nav-hamburger-bar"></span>
+      <span class="nav-hamburger-bar"></span>
+      <span class="nav-hamburger-bar"></span>
+    </button>
+    <nav class="nav site-nav" id="main-nav" role="navigation" aria-label="Main" data-nav-menu>
+      <a href="./index.html">Home</a>
       <a href="./pricing.html">Pricing</a>
       <a href="./about.html">About</a>
       <a href="./docs.html">Docs</a>
-      <a class="btn btn-wa" href="https://wa.me/61466873332?text=Hi%20C2C%2C%20keen%20to%20get%20set%20up." target="_blank" rel="noopener">WhatsApp</a>
+        <a href="./resources.html">Resources</a>
+      <a class="btn btn-wa" href="https://wa.me/61466873332?text=Hi%20C2C%2C%20keen%20to%20get%20set%20up.&utm_source=site&utm_medium=button&utm_campaign=whatsapp" target="_blank" rel="noopener">WhatsApp</a>
+      <button type="button" id="c2c-chat-cta" class="c2c-chat-cta" aria-controls="c2c-chatbot-container" aria-expanded="false">💬 Chat with C2C</button>
     </nav>
-    <button class="nav-hamburger" id="nav-hamburger" aria-controls="main-nav" aria-expanded="false" aria-label="Menu">
-      <span class="nav-hamburger-bar"></span><span class="nav-hamburger-bar"></span><span class="nav-hamburger-bar"></span>
-    </button>
   </div>
 </header>
+
+
 
 <main class="container">
   <h1>Docs done. Jobs won.</h1>
@@ -95,38 +97,11 @@ h1{margin:12px 0 8px;font-size:52px}.hero{font-size:1.2rem;color:#e9e9e9}
 <footer class="footer">
   <div class="container" style="display:flex;gap:14px;align-items:center;justify-content:space-between;flex-wrap:wrap">
     <span>© C2C Variations</span>
-    <span><a href="./pricing.html">See plans</a> · <a href="./about.html">About</a> · <a href="./privacy.html">Privacy</a> · <a href="./terms.html">Terms</a></span>
+    <span><a href="./pricing.html">See plans</a> · <a href="./about.html">About</a> · <a href="./resources.html">Resources</a> · <a href="./privacy.html">Privacy</a> · <a href="./terms.html">Terms</a></span>
   </div>
 </footer>
 
-<script>
-// Mobile menu that can't be blocked by other scripts
-(function(){
-  var btn=document.getElementById('nav-hamburger');
-  var nav=document.getElementById('main-nav');
-  if(!btn||!nav) return;
-  btn.addEventListener('click',function(e){
-    e.stopPropagation();
-    var open=nav.classList.toggle('open');
-    btn.setAttribute('aria-expanded', open ? 'true' : 'false');
-  });
-  document.addEventListener('click',function(e){
-    if(window.innerWidth>768) return;
-    if(!nav.classList.contains('open')) return;
-    if(!nav.contains(e.target) && e.target!==btn){ nav.classList.remove('open'); btn.setAttribute('aria-expanded','false'); }
-  });
-  window.addEventListener('resize',function(){ if(window.innerWidth>768){ nav.classList.remove('open'); btn.setAttribute('aria-expanded','false'); } });
-})();
-// smooth scroll for CTAs
-document.addEventListener('click',function(e){
-  var a=e.target.closest && e.target.closest('a[href^="#"]');
-  if(!a) return;
-  var id=a.getAttribute('href').slice(1);
-  var el=document.getElementById(id);
-  if(!el) return;
-  e.preventDefault();
-  el.scrollIntoView({behavior:'smooth', block:'start'});
-}, true);
-</script>
+<script src="assets/site-nav.js?v=1" defer></script>
+
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -37,7 +37,8 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@500;700;800&display=swap" rel="stylesheet">
   <link rel="preload" href="site-mobile.css?v=8" as="style" onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="site-mobile.css?v=8"></noscript>
-    <link rel="stylesheet" href="assets/nav-cta.hotfix.css?v=9">
+  <link rel="stylesheet" href="assets/site-nav.css?v=1">
+  <link rel="stylesheet" href="assets/nav-cta.hotfix.css?v=9">
   <style>
   :root{--bg:#000;--card:#0b0b0b;--muted:#c9c9c9;--text:#fff;--orange:#ff6a00;--orange-2:#ff8a3d;--outline:#222;--wa:#25D366}
   *{box-sizing:border-box}body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial;background:var(--bg);color:var(--text)}
@@ -105,96 +106,26 @@
   -->
 </head>
 <body>
-  <header class="site-header">
+  <header class="site-header" data-nav-root>
     <div class="container nav-row">
       <a class="brand" href="./index.html" aria-label="C2C Variations home">
         <img class="icon" src="./assets/logo-icon.jpg" alt="C2C icon">
       </a>
-      <nav class="nav" role="navigation" aria-label="Main">
-  <a href="./index.html">Home</a><a href="./pricing.html">Pricing</a><a href="./about.html">About</a><a href="./docs.html">Docs</a>
-  <a class="btn btn-wa" href="https://wa.me/61466873332?text=Hi%20C2C%2C%20keen%20to%20get%20set%20up.&utm_source=site&utm_medium=button&utm_campaign=whatsapp" target="_blank" rel="noopener">WhatsApp</a>
-  <button id="c2c-chat-cta" class="c2c-chat-cta" aria-controls="c2c-chatbot-container" aria-expanded="false">💬 Chat with C2C</button>
-      </nav>
-    </div>
-  <button class="nav-hamburger" id="nav-hamburger" aria-label="Open navigation" aria-controls="main-nav" aria-expanded="false" tabindex="0" style="z-index:10000;position:relative;">
+      <button class="nav-hamburger" type="button" data-nav-toggle aria-controls="main-nav" aria-expanded="false" aria-label="Open navigation">
         <span class="nav-hamburger-bar"></span>
         <span class="nav-hamburger-bar"></span>
         <span class="nav-hamburger-bar"></span>
       </button>
-      <nav class="nav" id="main-nav" role="navigation" aria-label="Main">
+      <nav class="nav site-nav" id="main-nav" role="navigation" aria-label="Main" data-nav-menu>
         <a href="./index.html">Home</a>
         <a href="./pricing.html">Pricing</a>
         <a href="./about.html">About</a>
         <a href="./docs.html">Docs</a>
+        <a href="./resources.html">Resources</a>
         <a class="btn btn-wa" href="https://wa.me/61466873332?text=Hi%20C2C%2C%20keen%20to%20get%20set%20up.&utm_source=site&utm_medium=button&utm_campaign=whatsapp" target="_blank" rel="noopener">WhatsApp</a>
-        <button id="c2c-chat-cta" class="c2c-chat-cta" aria-controls="c2c-chatbot-container" aria-expanded="false">💬 Chat with C2C</button>
+        <button type="button" id="c2c-chat-cta" class="c2c-chat-cta" aria-controls="c2c-chatbot-container" aria-expanded="false">💬 Chat with C2C</button>
       </nav>
-  <style>
-    /* Hamburger styles */
-    .nav-hamburger {
-      display: none;
-      flex-direction: column;
-      justify-content: center;
-      align-items: center;
-      width: 44px;
-      height: 44px;
-      background: none;
-      border: none;
-      cursor: pointer;
-      z-index: 100;
-      margin-left: 8px;
-    }
-    .nav-hamburger-bar {
-      width: 28px;
-      height: 4px;
-      background: #fff;
-      border-radius: 2px;
-      margin: 3px 0;
-      transition: all 0.3s;
-      display: block;
-    }
-    @media (max-width: 768px) {
-      .nav-hamburger { display: flex; }
-      .nav-row { gap: 8px; }
-      .nav {
-        position: absolute;
-        top: 64px;
-        right: 0;
-        left: 0;
-        background: rgba(0,0,0,0.98);
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 0;
-        padding: 0 0 12px 0;
-        box-shadow: 0 8px 24px rgba(0,0,0,0.18);
-        border-bottom: 1px solid var(--outline);
-        z-index: 99;
-        transform: translateY(-120%);
-        opacity: 0;
-        pointer-events: none;
-        transition: transform 0.25s, opacity 0.25s;
-      }
-      .nav.open {
-        transform: translateY(0);
-        opacity: 1;
-        pointer-events: auto;
-      }
-      .nav a, .nav .btn, .nav #c2c-chat-cta {
-        width: 100%;
-        text-align: left;
-        padding: 14px 24px;
-        border-radius: 0;
-        font-size: 1.1rem;
-        border: none;
-        background: none;
-        margin: 0;
-        box-shadow: none;
-      }
-      .nav .btn, .nav #c2c-chat-cta {
-        margin-top: 6px;
-      }
-    }
-  </style>
+    </div>
   </header>
   <main class="container">
 <div class="ticker"><div class="ticker-viewport">
@@ -238,7 +169,7 @@
   <footer class="footer">
     <div class="container footer-links-row">
       <span>© C2C Variations</span>
-      <span class="footer-links"><a href="https://www.c2cvariations.com.au/pricing">See plans</a><a href="https://www.c2cvariations.com.au/about">About</a><a href="https://www.c2cvariations.com.au/testimonials">Testimonials</a><a href="https://www.c2cvariations.com.au/partners">Partners</a><a href="https://www.c2cvariations.com.au/privacy">Privacy</a><a href="https://www.c2cvariations.com.au/terms">Terms</a></span>
+      <span class="footer-links"><a href="https://www.c2cvariations.com.au/pricing">See plans</a><a href="https://www.c2cvariations.com.au/about">About</a><a href="https://www.c2cvariations.com.au/resources">Resources</a><a href="https://www.c2cvariations.com.au/testimonials">Testimonials</a><a href="https://www.c2cvariations.com.au/partners">Partners</a><a href="https://www.c2cvariations.com.au/privacy">Privacy</a><a href="https://www.c2cvariations.com.au/terms">Terms</a></span>
     </div>
   <style>
     @media (max-width: 600px) {
@@ -290,47 +221,8 @@ document.addEventListener('click',function(e){
       </p>
     </div>
   </div>
+  <script src="assets/site-nav.js?v=1" defer></script>
   <script src="assets/chatbot.v6.js?v=1" defer></script>
-  <script>
-    // Hamburger nav toggle for mobile (robust, final)
-    document.addEventListener('DOMContentLoaded', function() {
-      var hamburger = document.getElementById('nav-hamburger');
-      var nav = document.getElementById('main-nav');
-      if (!hamburger || !nav) return;
-      hamburger.addEventListener('click', function(e){
-        e.stopPropagation();
-        var open = nav.classList.toggle('open');
-        hamburger.setAttribute('aria-expanded', open);
-      });
-      nav.addEventListener('click', function(e){
-        if(e.target.tagName==='A'||e.target.classList.contains('btn')||e.target.id==='c2c-chat-cta'){
-          nav.classList.remove('open');
-          hamburger.setAttribute('aria-expanded','false');
-        }
-      });
-      document.addEventListener('click', function(e){
-        if(window.innerWidth>768) return;
-        if(!nav.classList.contains('open')) return;
-        if(!nav.contains(e.target) && e.target!==hamburger){
-          nav.classList.remove('open');
-          hamburger.setAttribute('aria-expanded','false');
-        }
-      });
-      window.addEventListener('resize', function(){
-        if(window.innerWidth>768){
-          nav.classList.remove('open');
-          hamburger.setAttribute('aria-expanded','false');
-        }
-      });
-    });
-      window.addEventListener('resize', function(){
-        if(window.innerWidth>768){
-          nav.classList.remove('open');
-          hamburger.setAttribute('aria-expanded','false');
-        }
-      });
-  </script>
-</script>
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/index2.html
+++ b/index2.html
@@ -7,6 +7,7 @@
 <meta name="description" content="Lock in every variation, quote and agreement — same day. No disputes, no unpaid jobs, no bullshit.">
 <link rel="icon" href="./favicon.ico">
 <link rel="apple-touch-icon" href="./apple-touch-icon.png">
+<link rel="stylesheet" href="assets/site-nav.css?v=1">
 <style>
 :root{--bg:#000;--card:#0b0b0b;--muted:#c9c9c9;--text:#fff;--orange:#ff7a00;--orange-2:#ff8a3d;--outline:#222;--wa:#25D366}
 *{box-sizing:border-box}html,body{margin:0;padding:0}body{font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial;background:#000;color:#fff}
@@ -45,35 +46,37 @@ h1{margin:12px 0 8px;font-size:52px}.hero{font-size:1.2rem;color:#f3f3f3}.muted{
 .footer a{color:#ff8a3d;text-decoration:none}
 
 /* mobile menu */
-.nav-hamburger{display:none;flex-direction:column;justify-content:center;align-items:center;width:44px;height:44px;background:none;border:1px solid #222;border-radius:10px;cursor:pointer;margin-left:8px}
-.nav-hamburger-bar{width:28px;height:4px;background:#fff;border-radius:2px;margin:3px 0;display:block}
-@media (max-width: 768px){
-  .nav-hamburger{display:flex}
-  .nav-row{gap:8px}
-  .nav{position:absolute;top:64px;right:0;left:0;background:rgba(0,0,0,.98);flex-direction:column;align-items:flex-start;gap:0;padding:0 0 12px;border-bottom:1px solid var(--outline);z-index:99;transform:translateY(-120%);opacity:0;pointer-events:none;transition:transform .25s,opacity .25s}
-  .nav.open{transform:translateY(0);opacity:1;pointer-events:auto}
-  .nav a,.nav .btn{width:100%;text-align:left;padding:14px 24px;border-radius:0;font-size:1.05rem;border:none;background:none;margin:0;box-shadow:none}
-}
+
+
+
 /* hard kill overlays that could block taps */
 .backdrop,.overlay,.modal-backdrop,.menu-backdrop,.click-shield{pointer-events:none !important}
 </style>
 </head>
 <body>
-<header class="site-header">
+<header class="site-header" data-nav-root>
   <div class="container nav-row">
-    <a class="brand" href="./index.html"><img src="./assets/logo-icon.jpg" alt="C2C icon"></a>
-    <nav class="nav" id="main-nav" aria-label="Main">
-      <a href="./index.html" aria-current="page">Home</a>
+    <a class="brand" href="./index.html" aria-label="C2C Variations home">
+      <img class="icon" src="./assets/logo-icon.jpg" alt="C2C icon">
+    </a>
+    <button class="nav-hamburger" type="button" data-nav-toggle aria-controls="main-nav" aria-expanded="false" aria-label="Open navigation">
+      <span class="nav-hamburger-bar"></span>
+      <span class="nav-hamburger-bar"></span>
+      <span class="nav-hamburger-bar"></span>
+    </button>
+    <nav class="nav site-nav" id="main-nav" role="navigation" aria-label="Main" data-nav-menu>
+      <a href="./index.html">Home</a>
       <a href="./pricing.html">Pricing</a>
       <a href="./about.html">About</a>
       <a href="./docs.html">Docs</a>
-      <a class="btn btn-wa" href="https://wa.me/61466873332?text=Hi%20C2C%2C%20keen%20to%20get%20set%20up." target="_blank" rel="noopener">WhatsApp</a>
+        <a href="./resources.html">Resources</a>
+      <a class="btn btn-wa" href="https://wa.me/61466873332?text=Hi%20C2C%2C%20keen%20to%20get%20set%20up.&utm_source=site&utm_medium=button&utm_campaign=whatsapp" target="_blank" rel="noopener">WhatsApp</a>
+      <button type="button" id="c2c-chat-cta" class="c2c-chat-cta" aria-controls="c2c-chatbot-container" aria-expanded="false">💬 Chat with C2C</button>
     </nav>
-    <button class="nav-hamburger" id="nav-hamburger" aria-controls="main-nav" aria-expanded="false" aria-label="Menu">
-      <span class="nav-hamburger-bar"></span><span class="nav-hamburger-bar"></span><span class="nav-hamburger-bar"></span>
-    </button>
   </div>
 </header>
+
+
 
 <main class="container">
   <div class="ticker"><div class="ticker-viewport">
@@ -125,41 +128,11 @@ h1{margin:12px 0 8px;font-size:52px}.hero{font-size:1.2rem;color:#f3f3f3}.muted{
 <footer class="footer">
   <div class="container" style="display:flex;gap:14px;align-items:center;justify-content:space-between;flex-wrap:wrap">
     <span>© C2C Variations</span>
-    <span><a href="./pricing.html">See plans</a> · <a href="./about.html">About</a> · <a href="./privacy.html">Privacy</a> · <a href="./terms.html">Terms</a></span>
+    <span><a href="./pricing.html">See plans</a> · <a href="./about.html">About</a> · <a href="./resources.html">Resources</a> · <a href="./privacy.html">Privacy</a> · <a href="./terms.html">Terms</a></span>
   </div>
 </footer>
 
-<script>
-// hamburger (no dependencies)
-(function(){
-  var hamburger=document.getElementById('nav-hamburger');
-  var nav=document.getElementById('main-nav');
-  if(!hamburger||!nav) return;
-  hamburger.addEventListener('click',function(e){
-    e.stopPropagation();
-    var open=nav.classList.toggle('open');
-    hamburger.setAttribute('aria-expanded',open?'true':'false');
-  });
-  document.addEventListener('click',function(e){
-    if(window.innerWidth>768) return;
-    if(!nav.classList.contains('open')) return;
-    if(!nav.contains(e.target) && e.target!==hamburger){
-      nav.classList.remove('open');
-      hamburger.setAttribute('aria-expanded','false');
-    }
-  });
-  window.addEventListener('resize',function(){ if(window.innerWidth>768){ nav.classList.remove('open'); hamburger.setAttribute('aria-expanded','false'); } });
-})();
-// smooth scroll
-document.addEventListener('click',function(e){
-  var a=e.target.closest && e.target.closest('a[href^="#"]');
-  if(!a) return;
-  var id=a.getAttribute('href').slice(1);
-  var el=document.getElementById(id);
-  if(!el) return;
-  e.preventDefault();
-  el.scrollIntoView({behavior:'smooth', block:'start'});
-}, true);
-</script>
+<script src="assets/site-nav.js?v=1" defer></script>
+
 </body>
 </html>

--- a/partners.html
+++ b/partners.html
@@ -15,6 +15,7 @@
   <meta name="twitter:description" content="Lock scope changes, clear approvals, and time-stamped PDFs. Same-day setup across Australia.">
   <link rel="preload" href="site-mobile.css?v=8" as="style" onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="site-mobile.css?v=8"></noscript>
+  <link rel="stylesheet" href="assets/site-nav.css?v=1">
   <link rel="icon" href="./favicon.ico">
   <link rel="apple-touch-icon" href="./apple-touch-icon.png">
   <meta name="theme-color" content="#000000">
@@ -85,122 +86,28 @@
   -->
 </head>
 <body>
-  <header class="site-header">
-    <div class="container nav-row">
-      <a class="brand" href="./index.html" aria-label="C2C Variations home">
-        <img class="icon" src="./assets/logo-icon.jpg" alt="C2C icon">
-      </a>
-      <button class="nav-hamburger" id="nav-hamburger" aria-label="Open navigation" aria-controls="main-nav" aria-expanded="false" tabindex="0">
-        <span class="nav-hamburger-bar"></span>
-        <span class="nav-hamburger-bar"></span>
-        <span class="nav-hamburger-bar"></span>
-      </button>
-      <nav class="nav" id="main-nav" role="navigation" aria-label="Main">
-        <a href="./index.html">Home</a>
-        <a href="./pricing.html">Pricing</a>
-        <a href="./about.html">About</a>
-        <a href="./docs.html">Docs</a>
-        <a class="btn btn-wa" href="https://wa.me/61466873332?text=Hi%20C2C%2C%20keen%20to%20get%20set%20up.&utm_source=site&utm_medium=button&utm_campaign=whatsapp" target="_blank" rel="noopener">WhatsApp</a>
-        <button id="c2c-chat-cta" class="c2c-chat-cta" aria-controls="c2c-chatbot-container" aria-expanded="false">💬 Chat with C2C</button>
-      </nav>
-  <style>
-    .nav-hamburger {
-      display: none;
-      flex-direction: column;
-      justify-content: center;
-      align-items: center;
-      width: 44px;
-      height: 44px;
-      background: none;
-      border: none;
-      cursor: pointer;
-      z-index: 100;
-      margin-left: 8px;
-    }
-    .nav-hamburger-bar {
-      width: 28px;
-      height: 4px;
-      background: #fff;
-      border-radius: 2px;
-      margin: 3px 0;
-      transition: all 0.3s;
-      display: block;
-    }
-    @media (max-width: 768px) {
-      .nav-hamburger { display: flex; }
-      .nav-row { gap: 8px; }
-      .nav {
-        position: absolute;
-        top: 64px;
-        right: 0;
-        left: 0;
-        background: rgba(0,0,0,0.98);
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 0;
-        padding: 0 0 12px 0;
-        box-shadow: 0 8px 24px rgba(0,0,0,0.18);
-        border-bottom: 1px solid var(--outline);
-        z-index: 99;
-        transform: translateY(-120%);
-        opacity: 0;
-        pointer-events: none;
-        transition: transform 0.25s, opacity 0.25s;
-      }
-      .nav.open {
-        transform: translateY(0);
-        opacity: 1;
-        pointer-events: auto;
-      }
-      .nav a, .nav .btn, .nav #c2c-chat-cta {
-        width: 100%;
-        text-align: left;
-        padding: 14px 24px;
-        border-radius: 0;
-        font-size: 1.1rem;
-        border: none;
-        background: none;
-        margin: 0;
-        box-shadow: none;
-      }
-      .nav .btn, .nav #c2c-chat-cta {
-        margin-top: 6px;
-      }
-    }
-  </style>
-  <script>
-    (function(){
-      var hamburger = document.getElementById('nav-hamburger');
-      var nav = document.getElementById('main-nav');
-      if (!hamburger || !nav) return;
-      hamburger.addEventListener('click', function(){
-        var open = nav.classList.toggle('open');
-        hamburger.setAttribute('aria-expanded', open);
-      });
-      nav.addEventListener('click', function(e){
-        if(e.target.tagName==='A'||e.target.classList.contains('btn')||e.target.id==='c2c-chat-cta'){
-          nav.classList.remove('open');
-          hamburger.setAttribute('aria-expanded','false');
-        }
-      });
-      document.addEventListener('click', function(e){
-        if(window.innerWidth>768) return;
-        if(!nav.classList.contains('open')) return;
-        if(!nav.contains(e.target) && e.target!==hamburger){
-          nav.classList.remove('open');
-          hamburger.setAttribute('aria-expanded','false');
-        }
-      });
-      window.addEventListener('resize', function(){
-        if(window.innerWidth>768){
-          nav.classList.remove('open');
-          hamburger.setAttribute('aria-expanded','false');
-        }
-      });
-    })();
-  </script>
-    </div>
-  </header>
+  <header class="site-header" data-nav-root>
+  <div class="container nav-row">
+    <a class="brand" href="./index.html" aria-label="C2C Variations home">
+      <img class="icon" src="./assets/logo-icon.jpg" alt="C2C icon">
+    </a>
+    <button class="nav-hamburger" type="button" data-nav-toggle aria-controls="main-nav" aria-expanded="false" aria-label="Open navigation">
+      <span class="nav-hamburger-bar"></span>
+      <span class="nav-hamburger-bar"></span>
+      <span class="nav-hamburger-bar"></span>
+    </button>
+    <nav class="nav site-nav" id="main-nav" role="navigation" aria-label="Main" data-nav-menu>
+      <a href="./index.html">Home</a>
+      <a href="./pricing.html">Pricing</a>
+      <a href="./about.html">About</a>
+      <a href="./docs.html">Docs</a>
+        <a href="./resources.html">Resources</a>
+      <a class="btn btn-wa" href="https://wa.me/61466873332?text=Hi%20C2C%2C%20keen%20to%20get%20set%20up.&utm_source=site&utm_medium=button&utm_campaign=whatsapp" target="_blank" rel="noopener">WhatsApp</a>
+      <button type="button" id="c2c-chat-cta" class="c2c-chat-cta" aria-controls="c2c-chatbot-container" aria-expanded="false">💬 Chat with C2C</button>
+    </nav>
+  </div>
+</header>
+
   <main class="container">
 <a class="link" href="./index.html">← Back to homepage</a>
 <h1>Our Partners</h1>
@@ -217,7 +124,7 @@
   <footer class="footer">
     <div class="container" style="display:flex;justify-content:space-between;gap:16px;flex-wrap:wrap">
       <span>© C2C Variations</span>
-      <span class="footer-links"><a href="https://www.c2cvariations.com.au/pricing">See plans</a><a href="https://www.c2cvariations.com.au/about">About</a><a href="https://www.c2cvariations.com.au/testimonials">Testimonials</a><a href="https://www.c2cvariations.com.au/partners">Partners</a><a href="https://www.c2cvariations.com.au/privacy">Privacy</a><a href="https://www.c2cvariations.com.au/terms">Terms</a></span>
+      <span class="footer-links"><a href="https://www.c2cvariations.com.au/pricing">See plans</a><a href="https://www.c2cvariations.com.au/about">About</a><a href="https://www.c2cvariations.com.au/resources">Resources</a><a href="https://www.c2cvariations.com.au/testimonials">Testimonials</a><a href="https://www.c2cvariations.com.au/partners" aria-current="page">Partners</a><a href="https://www.c2cvariations.com.au/privacy">Privacy</a><a href="https://www.c2cvariations.com.au/terms">Terms</a></span>
     </div>
   </footer>
 
@@ -235,8 +142,8 @@
       </p>
     </div>
   </div>
+  <script src="assets/site-nav.js?v=1" defer></script>
   <script src="assets/chatbot.v6.js?v=1" defer></script>
-</script>
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/pricing.html
+++ b/pricing.html
@@ -10,6 +10,7 @@
   <link rel="canonical" href="https://www.c2cvariations.com.au/pricing">
   <link rel="preload" href="site-mobile.css?v=8" as="style" onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="site-mobile.css?v=8"></noscript>
+  <link rel="stylesheet" href="assets/site-nav.css?v=1">
   <link rel="stylesheet" href="assets/nav-cta.hotfix.css?v=9">
   <link rel="stylesheet" href="assets/chatbot.v6.css?v=1">
   <style>
@@ -41,16 +42,9 @@
     footer{padding:30px 0;color:#a7a7a7;border-top:1px solid var(--outline);margin-top:34px}
     footer a{color:#ff8a3d;text-decoration:none}
     /* mobile menu */
-    .nav-hamburger{display:none;flex-direction:column;justify-content:center;align-items:center;width:44px;height:44px;background:none;border:none;cursor:pointer;margin-left:8px}
-    .nav-hamburger-bar{width:28px;height:4px;background:#fff;border-radius:2px;margin:3px 0;transition:all .3s;display:block}
-    @media (max-width: 768px) {
-      .nav-hamburger{display:flex}
-      .nav-row{gap:8px}
-      .nav{position:absolute;top:64px;right:0;left:0;background:rgba(0,0,0,.98);flex-direction:column;align-items:flex-start;gap:0;padding:0 0 12px 0;border-bottom:1px solid var(--outline);z-index:99;transform:translateY(-120%);opacity:0;pointer-events:none;transition:transform .25s,opacity .25s}
-      .nav.open{transform:translateY(0);opacity:1;pointer-events:auto}
-      .nav a,.nav .btn,.nav #c2c-chat-cta{width:100%;text-align:left;padding:14px 24px;border-radius:0;font-size:1.1rem;border:none;background:none;margin:0;box-shadow:none}
-      .nav .btn,.nav #c2c-chat-cta{margin-top:6px}
-    }
+    
+    
+    
   </style>
   <meta name="c2c-fixpack" content="on">
   <style>
@@ -59,24 +53,28 @@
   </style>
 </head>
 <body>
-<header class="site-header" role="banner">
+<header class="site-header" data-nav-root>
   <div class="container nav-row">
     <a class="brand" href="./index.html" aria-label="C2C Variations home">
       <img class="icon" src="./assets/logo-icon.jpg" alt="C2C icon">
     </a>
-    <nav class="nav" id="main-nav" role="navigation" aria-label="Main">
+    <button class="nav-hamburger" type="button" data-nav-toggle aria-controls="main-nav" aria-expanded="false" aria-label="Open navigation">
+      <span class="nav-hamburger-bar"></span>
+      <span class="nav-hamburger-bar"></span>
+      <span class="nav-hamburger-bar"></span>
+    </button>
+    <nav class="nav site-nav" id="main-nav" role="navigation" aria-label="Main" data-nav-menu>
       <a href="./index.html">Home</a>
-      <a href="./pricing.html" aria-current="page">Pricing</a>
+      <a href="./pricing.html">Pricing</a>
       <a href="./about.html">About</a>
       <a href="./docs.html">Docs</a>
+        <a href="./resources.html">Resources</a>
       <a class="btn btn-wa" href="https://wa.me/61466873332?text=Hi%20C2C%2C%20keen%20to%20get%20set%20up.&utm_source=site&utm_medium=button&utm_campaign=whatsapp" target="_blank" rel="noopener">WhatsApp</a>
-      <button id="c2c-chat-cta" class="c2c-chat-cta" aria-controls="c2c-chatbot-container" aria-expanded="false">💬 Chat with C2C</button>
+      <button type="button" id="c2c-chat-cta" class="c2c-chat-cta" aria-controls="c2c-chatbot-container" aria-expanded="false">💬 Chat with C2C</button>
     </nav>
   </div>
-  <button class="nav-hamburger" id="nav-hamburger" aria-label="Open navigation" aria-controls="main-nav" aria-expanded="false">
-    <span class="nav-hamburger-bar"></span><span class="nav-hamburger-bar"></span><span class="nav-hamburger-bar"></span>
-  </button>
 </header>
+
 
 <main class="container">
   <h1>Pick your plan</h1>
@@ -142,6 +140,7 @@
   <div class="container" style="display:flex;gap:14px;align-items:center;justify-content:space-between;flex-wrap:wrap">
     <span>© C2C Variations</span>
     <span class="footer-links">
+      <a href="/resources">Resources</a> •
       <a href="/privacy">Privacy</a> •
       <a href="/terms">Terms</a>
     </span>
@@ -163,45 +162,10 @@
     </p>
   </div>
 </div>
-<script src="assets/chatbot.v6.js?v=1" defer></script>
+<script src="assets/stripe-links.js?v=1" defer></script>
+<script src="assets/site-nav.js?v=1" defer></script>
+  <script src="assets/chatbot.v6.js?v=1" defer></script>
 
-<script>
-  // hamburger toggle
-  (function(){
-    var hamburger=document.getElementById('nav-hamburger');
-    var nav=document.getElementById('main-nav');
-    if(hamburger&&nav){
-      hamburger.addEventListener('click',function(e){
-        e.stopPropagation();
-        var open=nav.classList.toggle('open');
-        hamburger.setAttribute('aria-expanded',open);
-      });
-      document.addEventListener('click',function(e){
-        if(window.innerWidth>768) return;
-        if(!nav.classList.contains('open')) return;
-        if(!nav.contains(e.target) && e.target!==hamburger){
-          nav.classList.remove('open');
-          hamburger.setAttribute('aria-expanded','false');
-        }
-      });
-      window.addEventListener('resize',function(){ if(window.innerWidth>768){ nav.classList.remove('open'); hamburger.setAttribute('aria-expanded','false'); } });
-    }
-  })();
 
-  // force navigation to Stripe on click/keyboard, capture phase so nothing blocks
-  (function(){
-    function go(h){ try{ window.location.assign(h); }catch(e){} }
-    document.addEventListener('click',function(e){
-      var a=e.target.closest && e.target.closest('a[href^="https://buy.stripe.com"]');
-      if(a){ e.preventDefault(); e.stopPropagation(); go(a.href); }
-    }, true);
-    document.addEventListener('keydown',function(e){
-      if(e.key!=='Enter' && e.key!==' ') return;
-      var el=document.activeElement;
-      var a=el && el.closest && el.closest('a[href^="https://buy.stripe.com"]');
-      if(a){ e.preventDefault(); e.stopPropagation(); go(a.href); }
-    }, true);
-  })();
-</script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -16,6 +16,7 @@
   <meta name="twitter:description" content="Lock scope changes, clear approvals, and time-stamped PDFs. Same-day setup across Australia.">
   <link rel="preload" href="site-mobile.css?v=8" as="style" onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="site-mobile.css?v=8"></noscript>
+  <link rel="stylesheet" href="assets/site-nav.css?v=1">
   <style>
     :root{--bg:#000;--fg:#fff;--muted:#a7a7a7;--card:#0d0d0f;--line:#222;--accent:#ff8a3d;--wa:#25D366;}
     html{-webkit-text-size-adjust:100%;text-size-adjust:100%;}
@@ -39,120 +40,28 @@
   -->
 </head>
 <body>
-<header style="position:sticky;top:0;z-index:50;background:#000;border-bottom:1px solid #222;">
-  <div style="max-width:1100px;margin:0 auto;padding:14px 20px;display:flex;gap:16px;align-items:center;">
-    <a href="/" style="font-weight:800;color:#ff8a3d;text-decoration:none">Home</a>
-    <button class="nav-hamburger" id="nav-hamburger" aria-label="Open navigation" aria-controls="main-nav" aria-expanded="false" tabindex="0" style="margin-left:auto;">
+<header class="site-header" data-nav-root>
+  <div class="container nav-row">
+    <a class="brand" href="./index.html" aria-label="C2C Variations home">
+      <img class="icon" src="./assets/logo-icon.jpg" alt="C2C icon">
+    </a>
+    <button class="nav-hamburger" type="button" data-nav-toggle aria-controls="main-nav" aria-expanded="false" aria-label="Open navigation">
       <span class="nav-hamburger-bar"></span>
       <span class="nav-hamburger-bar"></span>
       <span class="nav-hamburger-bar"></span>
     </button>
-    <nav id="main-nav" style="display:flex;gap:16px;margin-left:auto" role="navigation" aria-label="Main">
-      <a href="/pricing" style="color:#ff8a3d;text-decoration:none">Pricing</a>
-      <a href="/docs" style="color:#ff8a3d;text-decoration:none">Docs</a>
-      <a href="/about" style="color:#ff8a3d;text-decoration:none">About</a>
-      <a href="/privacy" style="color:#ff8a3d;text-decoration:none">Privacy</a>
-      <a href="/terms" style="color:#ff8a3d;text-decoration:none">Terms</a>
+    <nav class="nav site-nav" id="main-nav" role="navigation" aria-label="Main" data-nav-menu>
+      <a href="./index.html">Home</a>
+      <a href="./pricing.html">Pricing</a>
+      <a href="./about.html">About</a>
+      <a href="./docs.html">Docs</a>
+        <a href="./resources.html">Resources</a>
       <a class="btn btn-wa" href="https://wa.me/61466873332?text=Hi%20C2C%2C%20keen%20to%20get%20set%20up.&utm_source=site&utm_medium=button&utm_campaign=whatsapp" target="_blank" rel="noopener">WhatsApp</a>
-      <button id="c2c-chat-cta" class="c2c-chat-cta" aria-controls="c2c-chatbot-container" aria-expanded="false">💬 Chat with C2C</button>
+      <button type="button" id="c2c-chat-cta" class="c2c-chat-cta" aria-controls="c2c-chatbot-container" aria-expanded="false">💬 Chat with C2C</button>
     </nav>
   </div>
-  <style>
-    .nav-hamburger {
-      display: none;
-      flex-direction: column;
-      justify-content: center;
-      align-items: center;
-      width: 44px;
-      height: 44px;
-      background: none;
-      border: none;
-      cursor: pointer;
-      z-index: 100;
-      margin-left: 8px;
-    }
-    .nav-hamburger-bar {
-      width: 28px;
-      height: 4px;
-      background: #fff;
-      border-radius: 2px;
-      margin: 3px 0;
-      transition: all 0.3s;
-      display: block;
-    }
-    @media (max-width: 768px) {
-      .nav-hamburger { display: flex !important; }
-      #main-nav {
-        position: absolute;
-        top: 64px;
-        right: 0;
-        left: 0;
-        background: rgba(0,0,0,0.98);
-        flex-direction: column !important;
-        align-items: flex-start !important;
-        gap: 0 !important;
-        padding: 0 0 12px 0 !important;
-        box-shadow: 0 8px 24px rgba(0,0,0,0.18);
-        border-bottom: 1px solid #222;
-        z-index: 99;
-        transform: translateY(-120%);
-        opacity: 0;
-        pointer-events: none;
-        transition: transform 0.25s, opacity 0.25s;
-      }
-      #main-nav.open {
-        transform: translateY(0);
-        opacity: 1;
-        pointer-events: auto;
-      }
-      #main-nav a, #main-nav .btn, #main-nav #c2c-chat-cta {
-        width: 100%;
-        text-align: left;
-        padding: 14px 24px;
-        border-radius: 0;
-        font-size: 1.1rem;
-        border: none;
-        background: none;
-        margin: 0;
-        box-shadow: none;
-      }
-      #main-nav .btn, #main-nav #c2c-chat-cta {
-        margin-top: 6px;
-      }
-    }
-  </style>
-  <script>
-    (function(){
-      var hamburger = document.getElementById('nav-hamburger');
-      var nav = document.getElementById('main-nav');
-      if (!hamburger || !nav) return;
-      hamburger.addEventListener('click', function(){
-        var open = nav.classList.toggle('open');
-        hamburger.setAttribute('aria-expanded', open);
-      });
-      nav.addEventListener('click', function(e){
-        if(e.target.tagName==='A'||e.target.classList.contains('btn')||e.target.id==='c2c-chat-cta'){
-          nav.classList.remove('open');
-          hamburger.setAttribute('aria-expanded','false');
-        }
-      });
-      document.addEventListener('click', function(e){
-        if(window.innerWidth>768) return;
-        if(!nav.classList.contains('open')) return;
-        if(!nav.contains(e.target) && e.target!==hamburger){
-          nav.classList.remove('open');
-          hamburger.setAttribute('aria-expanded','false');
-        }
-      });
-      window.addEventListener('resize', function(){
-        if(window.innerWidth>768){
-          nav.classList.remove('open');
-          hamburger.setAttribute('aria-expanded','false');
-        }
-      });
-    })();
-  </script>
 </header>
+
 
   <div class="wrap">
     <h1>Privacy Policy</h1>
@@ -217,7 +126,7 @@
   <footer class="footer">
     <div class="container footer-links-row">
       <span>© C2C Variations</span>
-      <span class="footer-links"><a href="https://www.c2cvariations.com.au/pricing">See plans</a><a href="https://www.c2cvariations.com.au/about">About</a><a href="https://www.c2cvariations.com.au/testimonials">Testimonials</a><a href="https://www.c2cvariations.com.au/partners">Partners</a><a href="https://www.c2cvariations.com.au/privacy">Privacy</a><a href="https://www.c2cvariations.com.au/terms">Terms</a></span>
+      <span class="footer-links"><a href="https://www.c2cvariations.com.au/pricing">See plans</a><a href="https://www.c2cvariations.com.au/about">About</a><a href="https://www.c2cvariations.com.au/resources">Resources</a><a href="https://www.c2cvariations.com.au/testimonials">Testimonials</a><a href="https://www.c2cvariations.com.au/partners">Partners</a><a href="https://www.c2cvariations.com.au/privacy">Privacy</a><a href="https://www.c2cvariations.com.au/terms">Terms</a></span>
     </div>
   <style>
     @media (max-width: 600px) {
@@ -242,8 +151,8 @@
     }
   </style>
   </footer>
+  <script src="assets/site-nav.js?v=1" defer></script>
   <script src="assets/chatbot.v6.js?v=1" defer></script>
-</script>
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/resources.html
+++ b/resources.html
@@ -1,463 +1,520 @@
 <!doctype html>
 <html lang="en">
 <head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1">
-<title>C2C Variations — Resources</title>
-<meta name="description" content="All the C2C resources: guides, templates, calculators, checklists, legal notes, videos and FAQs — searchable, filterable, and downloadable.">
-<link rel="icon" href="./favicon.ico">
-<link rel="apple-touch-icon" href="./apple-touch-icon.png">
-<style>
-/* ---------- C2C Resources (scoped) ---------- */
-:root{--c2c-bg:#000;--c2c-card:#0b0b0b;--c2c-muted:#bdbdbd;--c2c-text:#fff;--c2c-orange:#ff7a00;--c2c-orange-2:#ff8a3d;--c2c-outline:#222;--c2c-wa:#25D366;--c2c-green:#66d37e;--c2c-red:#ff4d4d}
-#resource-app{color:var(--c2c-text);background:var(--c2c-bg);font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial;line-height:1.45}
-#resource-app *{box-sizing:border-box}
-#resource-app a{color:var(--c2c-orange-2);text-decoration:none}
-#resource-app .muted{color:var(--c2c-muted)}
-#resource-app .container{max-width:1200px;margin:0 auto;padding:24px}
-#resource-app .surface{background:var(--c2c-card);border:1px solid var(--c2c-outline);border-radius:16px}
-#resource-app .btn{display:inline-flex;align-items:center;justify-content:center;gap:10px;border-radius:12px;padding:10px 14px;font-weight:800;text-decoration:none;cursor:pointer;border:1px solid var(--c2c-outline);transition:transform .12s ease, box-shadow .12s ease;background:#101010;color:var(--c2c-text)}
-#resource-app .btn:hover{transform:translateY(-1px);box-shadow:0 6px 18px rgba(255,122,0,.15)}
-#resource-app .btn-primary{background:var(--c2c-orange);color:#000;border-color:var(--c2c-orange)}
-#resource-app .btn-outline{background:transparent;color:var(--c2c-orange);border-color:var(--c2c-orange)}
-#resource-app .btn-ghost{background:#0b0b0b;border-color:#2a2a2a;color:var(--c2c-text)}
-#resource-app .btn-small{padding:8px 10px;border-radius:10px;font-weight:700}
-#resource-app h1{margin:8px 0 0;font-size:42px}
-#resource-app h2{margin:24px 0 10px;font-size:28px}
-#resource-app h3{margin:14px 0 8px;font-size:20px}
-#resource-app .pill{display:inline-flex;align-items:center;gap:8px;background:#0f0f0f;border:1px solid var(--c2c-outline);padding:5px 10px;border-radius:999px;font-size:.9rem;color:#e7e7e7}
-#resource-app .chip{display:inline-flex;align-items:center;gap:6px;background:#101010;border:1px solid var(--c2c-outline);padding:6px 10px;border-radius:999px;font-size:.9rem;color:#e7e7e7;cursor:pointer}
-#resource-app .chip.active{background:var(--c2c-orange);color:#000;border-color:var(--c2c-orange)}
-#resource-app .row{display:flex;gap:16px;align-items:center;flex-wrap:wrap}
-#resource-app .grid{display:grid;grid-template-columns:repeat(12,1fr);gap:16px}
-#resource-app .left{grid-column:span 9}
-#resource-app .right{grid-column:span 3;position:sticky;top:70px;height:max-content}
-#resource-app .card{padding:16px;border-radius:16px;background:var(--c2c-card);border:1px solid var(--c2c-outline)}
-#resource-app .card:hover{box-shadow:0 16px 30px rgba(0,0,0,.35)}
-#resource-app .resource-card{display:grid;grid-template-columns:72px 1fr;gap:14px}
-#resource-app .resource-card .icon{width:72px;height:72px;border-radius:12px;background:linear-gradient(135deg,#151515,#0a0a0a);border:1px solid var(--c2c-outline);display:flex;align-items:center;justify-content:center;font-weight:900;color:#ffb580;letter-spacing:.5px}
-#resource-app .resource-card .title{font-size:18px;margin:0 0 6px}
-#resource-app .resource-card .meta{display:flex;gap:10px;flex-wrap:wrap;margin-top:6px}
-#resource-app .resource-card .actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:10px}
-#resource-app .section{margin:22px 0}
-#resource-app .kbd{display:inline-block;border:1px solid #444;border-bottom-width:3px;border-radius:8px;padding:0 7px;margin:0 2px;background:#111;font-weight:800}
-#resource-app .toc a{display:block;padding:8px 10px;border-radius:10px;color:#eaeaea;border:1px solid transparent}
-#resource-app .toc a:hover{border-color:#333}
-#resource-app .toc .active{background:#101010;border-color:#222;color:#fff}
-#resource-app .searchbar{display:flex;gap:10px;flex-wrap:wrap;align-items:center}
-#resource-app input[type="search"], #resource-app input[type="text"], #resource-app select{background:#0b0b0b;border:1px solid #2a2a2a;border-radius:12px;color:#fff;padding:10px 12px;font-size:15px}
-#resource-app input[type="number"]{background:#0b0b0b;border:1px solid #2a2a2a;border-radius:10px;color:#fff;padding:8px 10px;width:110px}
-#resource-app label{font-size:.95rem;color:#e6e6e6}
-#resource-app .divider{height:1px;background:var(--c2c-outline);margin:18px 0}
-#resource-app .kbd-row{font-size:.95rem}
-#resource-app .taglist{display:flex;gap:10px;flex-wrap:wrap}
-#resource-app .notice{padding:10px 12px;border-radius:10px;border:1px solid #333;background:#0d0d0d;color:#ddd}
-#resource-app .success{border-color:#1f532a;background:#0b2011;color:#a7eebb}
-#resource-app .warn{border-color:#704c00;background:#1f1500;color:#ffd28a}
-#resource-app .calc-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:12px}
-#resource-app .list{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:14px}
-#resource-app .faq dt{background:#0c0c0c;border:1px solid #2a2a2a;padding:12px;border-radius:12px;cursor:pointer}
-#resource-app .faq dd{margin:0 0 12px;padding:10px 12px;border-left:3px solid #2a2a2a}
-#resource-app .floating-top{position:fixed;right:16px;bottom:18px;z-index:40}
-#resource-app .kbd-help{position:fixed;right:16px;bottom:70px;z-index:40}
-#resource-app .empty{padding:30px;border:1px dashed #333;border-radius:14px;text-align:center;color:#ddd}
-/* Print tweaks */
-@media print{
-  #resource-app .right, #resource-app .floating-top, #resource-app .kbd-help, #resource-app .searchbar{display:none!important}
-  #resource-app .container{padding:0}
-  #resource-app .card{break-inside:avoid}
-}
-</style>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <title>C2C Variations — Resources</title>
+  <meta name="description" content="Guides, calculators, generators and FAQs for C2C customers. Save the bits you need for later and download ready-to-send paperwork.">
+  <link rel="icon" href="./favicon.ico">
+  <link rel="apple-touch-icon" href="./apple-touch-icon.png">
+  <link rel="preload" href="site-mobile.css?v=8" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="site-mobile.css?v=8"></noscript>
+  <link rel="stylesheet" href="assets/site-nav.css?v=1">
+  <link rel="stylesheet" href="assets/nav-cta.hotfix.css?v=9">
+  <link rel="stylesheet" href="assets/chatbot.v6.css?v=1">
+  <style>
+    body{margin:0;background:#000;color:#fff;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility}
+    a{color:#ff8a3d;text-decoration:none}
+    a:hover,a:focus{text-decoration:underline}
+    #c2c-resources{max-width:1100px;margin:0 auto;padding:24px}
+    #c2c-resources .res-hero{display:flex;flex-direction:column;gap:10px;margin-bottom:26px}
+    #c2c-resources .res-pill{display:inline-flex;align-items:center;gap:8px;background:#101010;border:1px solid #222;border-radius:999px;padding:6px 14px;font-size:.9rem;color:#f2f2f2;width:max-content}
+    #c2c-resources h1{margin:0;font-size:clamp(36px,5vw,56px)}
+    #c2c-resources p{margin:0;color:#cccccc}
+    #c2c-resources .res-layout{display:grid;grid-template-columns:minmax(0,3fr) minmax(240px,1fr);gap:24px;align-items:start}
+    #c2c-resources .res-section{margin-bottom:32px}
+    #c2c-resources .res-section h2{margin:0 0 12px;font-size:28px}
+    #c2c-resources .res-card-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:16px}
+    #c2c-resources .res-card{background:#0b0b0b;border:1px solid #222;border-radius:16px;padding:18px;display:flex;flex-direction:column;gap:12px}
+    #c2c-resources label{display:block;font-size:.95rem;color:#e2e2e2;margin-bottom:6px}
+    #c2c-resources input[type="text"],
+    #c2c-resources input[type="number"],
+    #c2c-resources textarea{width:100%;background:#111;border:1px solid #2a2a2a;border-radius:10px;color:#fff;padding:10px;font-size:.95rem}
+    #c2c-resources textarea{min-height:120px;resize:vertical}
+    #c2c-resources .res-buttons{display:flex;flex-wrap:wrap;gap:10px;margin-top:4px}
+    #c2c-resources button.res-btn,
+    #c2c-resources a.res-btn{display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:10px 16px;border-radius:12px;font-weight:700;border:1px solid #2a2a2a;background:#151515;color:#fff;cursor:pointer;transition:transform .12s ease, box-shadow .12s ease}
+    #c2c-resources button.res-btn:hover,
+    #c2c-resources a.res-btn:hover{transform:translateY(-1px);box-shadow:0 10px 24px rgba(0,0,0,.35)}
+    #c2c-resources button.res-primary{background:#ff7a00;color:#000;border-color:#ff7a00}
+    #c2c-resources .res-output{padding:10px 12px;border-radius:12px;background:#111;border:1px solid #262626;color:#dcdcdc;font-size:.95rem}
+    #c2c-resources .res-preview{background:#0e0e0e;border:1px solid #262626;border-radius:12px;padding:12px;color:#eaeaea;font-family:"SF Mono",Menlo,monospace;white-space:pre-wrap;min-height:110px}
+    #c2c-resources .res-generator{display:flex;flex-direction:column;gap:12px}
+    #c2c-resources .res-generator legend{font-weight:700;margin-bottom:6px}
+    #c2c-resources .res-guide-list{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:16px}
+    #c2c-resources .res-guide{background:#0b0b0b;border:1px solid #222;border-radius:16px;padding:16px;display:flex;flex-direction:column;gap:10px}
+    #c2c-resources .res-guide h3{margin:0;font-size:20px}
+    #c2c-resources .res-tag{display:inline-flex;align-items:center;gap:6px;border-radius:999px;background:#161616;border:1px solid #333;padding:4px 10px;font-size:.8rem;color:#cfcfcf}
+    #c2c-resources .res-sidebar{display:flex;flex-direction:column;gap:16px}
+    #c2c-resources .res-panel{background:#0b0b0b;border:1px solid #222;border-radius:16px;padding:16px}
+    #c2c-resources .res-panel h2{margin:0 0 10px;font-size:20px}
+    #c2c-resources .res-quick-links{display:flex;flex-wrap:wrap;gap:8px}
+    #c2c-resources .res-quick-links a{display:inline-flex;align-items:center;gap:6px;padding:8px 12px;border-radius:10px;background:#131313;border:1px solid #2a2a2a;color:#e9e9e9;text-decoration:none;font-size:.9rem}
+    #c2c-resources .res-quick-links a:hover{border-color:#ff7a00;color:#ffb97a}
+    #c2c-resources .res-toc{display:flex;flex-direction:column;gap:6px}
+    #c2c-resources .res-toc a{padding:6px 10px;border-radius:10px;border:1px solid transparent;color:#e9e9e9;text-decoration:none;font-size:.9rem}
+    #c2c-resources .res-toc a.active{border-color:#ff7a00;background:#1b1204;color:#ffb97a}
+    #c2c-resources .res-saved{display:flex;flex-direction:column;gap:8px}
+    #c2c-resources .res-saved-item{display:flex;justify-content:space-between;align-items:center;gap:12px;padding:8px 12px;border-radius:10px;background:#111;border:1px solid #262626;color:#e9e9e9;font-size:.9rem}
+    #c2c-resources .res-empty{margin:0;color:#a6a6a6;font-size:.9rem}
+    #c2c-resources .res-link-button{background:none;border:none;padding:0;color:#ff8a3d;font-size:.85rem;cursor:pointer;text-decoration:underline}
+    #c2c-resources .res-faqs details{background:#0c0c0c;border:1px solid #222;border-radius:14px;margin-bottom:10px;padding:12px}
+    #c2c-resources .res-faqs summary{cursor:pointer;font-weight:600;color:#f4f4f4}
+    #c2c-resources .res-faqs p{margin-top:10px;color:#d4d4d4}
+    .res-footer{margin:40px 0 0;padding:24px;background:#050505;border-top:1px solid #1c1c1c}
+    .res-footer-inner{max-width:1100px;margin:0 auto;display:flex;flex-wrap:wrap;gap:12px;align-items:center;justify-content:space-between;color:#b5b5b5;font-size:.9rem}
+    .res-footer-links{display:flex;flex-wrap:wrap;gap:12px}
+    .res-footer-links a{text-decoration:none;color:#ff8a3d}
+    .res-footer-links a[aria-current]{font-weight:700}
+    @media (max-width:960px){
+      #c2c-resources{padding:20px}
+      #c2c-resources .res-layout{grid-template-columns:1fr}
+      #c2c-resources .res-sidebar{order:-1}
+    }
+    @media (prefers-reduced-motion:reduce){
+      #c2c-resources button.res-btn,
+      #c2c-resources a.res-btn{transition:none}
+    }
+  </style>
 </head>
 <body>
-<main id="resource-app" class="container">
-  <header class="row" style="justify-content:space-between;align-items:flex-start">
-    <div>
-      <div class="pill">New section</div>
-      <h1>Resources</h1>
-      <p class="muted">Everything in one place: guides, templates, calculators, checklists, legal notes, integration helpers, videos, and FAQs. Search, filter, save, and download.</p>
-      <div class="row searchbar">
-        <input id="ra-search" type="search" placeholder="Search guides, templates, laws, FAQs…" aria-label="Search resources">
-        <select id="ra-sort" aria-label="Sort">
-          <option value="new">Newest</option>
-          <option value="popular">Popular</option>
-          <option value="az">A → Z</option>
-        </select>
-        <button class="btn btn-ghost btn-small" id="ra-clear">Clear</button>
-        <button class="btn btn-primary btn-small" id="ra-save-export">Export My Saved</button>
-        <div class="kbd-row muted">Tips: press <span class="kbd">/</span> to focus search • <span class="kbd">?</span> for shortcuts</div>
-      </div>
-      <div class="taglist" id="ra-filters"></div>
+  <header class="site-header" data-nav-root>
+    <div class="container nav-row">
+      <a class="brand" href="./index.html" aria-label="C2C Variations home">
+        <img class="icon" src="./assets/logo-icon.jpg" alt="C2C icon">
+      </a>
+      <button class="nav-hamburger" type="button" data-nav-toggle aria-controls="main-nav" aria-expanded="false" aria-label="Open navigation">
+        <span class="nav-hamburger-bar"></span>
+        <span class="nav-hamburger-bar"></span>
+        <span class="nav-hamburger-bar"></span>
+      </button>
+      <nav class="nav site-nav" id="main-nav" role="navigation" aria-label="Main" data-nav-menu>
+        <a href="./index.html">Home</a>
+        <a href="./pricing.html">Pricing</a>
+        <a href="./about.html">About</a>
+        <a href="./docs.html">Docs</a>
+        <a href="./resources.html" aria-current="page">Resources</a>
+        <a class="btn btn-wa" href="https://wa.me/61466873332?text=Hi%20C2C%2C%20keen%20to%20get%20set%20up.&utm_source=site&utm_medium=button&utm_campaign=whatsapp" target="_blank" rel="noopener">WhatsApp</a>
+        <button type="button" id="c2c-chat-cta" class="c2c-chat-cta" aria-controls="c2c-chatbot-container" aria-expanded="false">💬 Chat with C2C</button>
+      </nav>
     </div>
   </header>
 
-  <section class="grid" style="margin-top:12px">
-    <div class="left">
-      <section id="featured" class="section">
-        <h2>Featured</h2>
-        <div id="ra-featured" class="list"></div>
-      </section>
+  <main id="c2c-resources">
+    <section class="res-hero" id="overview">
+      <div class="res-pill">Resources hub</div>
+      <h1>Tools, templates & answers</h1>
+      <p>Estimate jobs, generate paperwork, skim guides and stash the bits you need for later. Everything lives in one place so crews can keep moving.</p>
+    </section>
 
-      <div class="divider"></div>
-
-      <section id="all" class="section">
-        <h2>All resources</h2>
-        <div id="ra-results" class="list"></div>
-      </section>
-
-      <div class="divider"></div>
-
-      <section id="calculators" class="section">
-        <h2>Calculators</h2>
-        <div class="calc-grid">
-          <div class="card surface">
-            <h3>GST Calculator (AU 10%)</h3>
-            <label>Amount (excl. GST)</label><br>
-            <input type="number" id="gst-base" value="100">
-            <div class="row" style="margin-top:10px">
-              <button class="btn btn-primary btn-small" id="gst-calc">Calculate</button>
-              <div id="gst-out" class="pill">GST: A$10.00 • Total: A$110.00</div>
-            </div>
+    <div class="res-layout">
+      <div class="res-main">
+        <section id="res-calculators" class="res-section" data-section>
+          <h2>Calculators</h2>
+          <div class="res-card-grid">
+            <article class="res-card" aria-labelledby="gst-heading">
+              <h3 id="gst-heading">GST (10%)</h3>
+              <label for="res-gst-base">Amount excluding GST</label>
+              <input type="number" id="res-gst-base" value="100" min="0" step="0.01">
+              <label for="res-gst-total">Amount including GST</label>
+              <input type="number" id="res-gst-total" value="110" min="0" step="0.01">
+              <div class="res-buttons">
+                <button type="button" class="res-btn res-primary" data-gst="from-base">From ex GST</button>
+                <button type="button" class="res-btn" data-gst="from-total">From inc GST</button>
+              </div>
+              <div class="res-output" id="res-gst-output">GST: A$10.00 • Total: A$110.00</div>
+            </article>
+            <article class="res-card" aria-labelledby="day-heading">
+              <h3 id="day-heading">Day-rate calculator</h3>
+              <label for="res-day-hours">Hours per day</label>
+              <input type="number" id="res-day-hours" value="8" min="0" step="0.5">
+              <label for="res-day-rate">Hourly rate (A$)</label>
+              <input type="number" id="res-day-rate" value="95" min="0" step="0.01">
+              <div class="res-buttons">
+                <button type="button" class="res-btn res-primary" id="res-day-calc">Calculate</button>
+              </div>
+              <div class="res-output" id="res-day-output">Day rate: A$760.00</div>
+            </article>
+            <article class="res-card" aria-labelledby="variation-heading">
+              <h3 id="variation-heading">Variation estimator</h3>
+              <label for="res-var-materials">Materials (A$)</label>
+              <input type="number" id="res-var-materials" value="250" min="0" step="0.01">
+              <label for="res-var-hours">Labour hours</label>
+              <input type="number" id="res-var-hours" value="4" min="0" step="0.1">
+              <label for="res-var-rate">Hourly rate (A$)</label>
+              <input type="number" id="res-var-rate" value="95" min="0" step="0.01">
+              <label for="res-var-markup">Markup %</label>
+              <input type="number" id="res-var-markup" value="15" min="0" step="1">
+              <div class="res-buttons">
+                <button type="button" class="res-btn res-primary" id="res-var-calc">Estimate</button>
+              </div>
+              <div class="res-output" id="res-var-output">Quote: A$0.00 (ex GST)</div>
+            </article>
           </div>
-          <div class="card surface">
-            <h3>Variation Quote Estimator</h3>
-            <label>Materials (A$)</label><br><input type="number" id="vq-mat" value="250">
-            <label style="margin-left:8px">Labour hours</label><br><input type="number" id="vq-hours" value="4">
-            <label style="margin-left:8px">Hourly rate (A$)</label><br><input type="number" id="vq-rate" value="95">
-            <label style="margin-left:8px">Markup %</label><br><input type="number" id="vq-markup" value="15">
-            <div class="row" style="margin-top:10px">
-              <button class="btn btn-primary btn-small" id="vq-calc">Estimate</button>
-              <div id="vq-out" class="pill">Quote: A$??</div>
-            </div>
+        </section>
+
+        <section id="res-generators" class="res-section" data-section>
+          <h2>Generators</h2>
+          <div class="res-card-grid">
+            <article class="res-card">
+              <h3>Claim intake form</h3>
+              <form class="res-generator" data-generator="claim">
+                <label>Client name<input type="text" name="client" required placeholder="Client / company"></label>
+                <label>Job address<input type="text" name="address" required placeholder="Where is the work?"></label>
+                <label>Issue summary<textarea name="issue" required placeholder="Short description"></textarea></label>
+                <label>Contact number<input type="text" name="contact" placeholder="Optional contact"></label>
+                <div class="res-buttons">
+                  <button type="button" class="res-btn res-primary" data-action="preview">Preview</button>
+                  <button type="button" class="res-btn" data-action="download" disabled>Download</button>
+                </div>
+                <pre class="res-preview" aria-live="polite"></pre>
+              </form>
+            </article>
+            <article class="res-card">
+              <h3>Variation agreement</h3>
+              <form class="res-generator" data-generator="variation">
+                <label>Client / approver<input type="text" name="client" required placeholder="Who signs off?"></label>
+                <label>Variation details<textarea name="details" required placeholder="Scope, reason and price"></textarea></label>
+                <label>Quoted amount (A$)<input type="number" name="amount" min="0" step="0.01" required value="0"></label>
+                <label>Requested completion date<input type="text" name="date" placeholder="Optional"></label>
+                <div class="res-buttons">
+                  <button type="button" class="res-btn res-primary" data-action="preview">Preview</button>
+                  <button type="button" class="res-btn" data-action="download" disabled>Download</button>
+                </div>
+                <pre class="res-preview" aria-live="polite"></pre>
+              </form>
+            </article>
+            <article class="res-card">
+              <h3>VIC plumbing compliance</h3>
+              <form class="res-generator" data-generator="vic">
+                <label>Licence number<input type="text" name="licence" required placeholder="e.g. 12345"></label>
+                <label>Site address<input type="text" name="address" required placeholder="Where was the work?"></label>
+                <label>Compliance summary<textarea name="notes" required placeholder="Work completed / standards met"></textarea></label>
+                <label>Date completed<input type="text" name="date" placeholder="dd/mm/yyyy"></label>
+                <div class="res-buttons">
+                  <button type="button" class="res-btn res-primary" data-action="preview">Preview</button>
+                  <button type="button" class="res-btn" data-action="download" disabled>Download</button>
+                </div>
+                <pre class="res-preview" aria-live="polite"></pre>
+              </form>
+            </article>
           </div>
-          <div class="card surface">
-            <h3>Day-rate Calculator</h3>
-            <label>Hours per day</label><br><input type="number" id="dr-hours" value="8">
-            <label style="margin-left:8px">Hourly rate</label><br><input type="number" id="dr-rate" value="95">
-            <div class="row" style="margin-top:10px">
-              <button class="btn btn-primary btn-small" id="dr-calc">Calculate</button>
-              <div id="dr-out" class="pill">Day rate: A$760</div>
-            </div>
+        </section>
+
+        <section id="res-guides" class="res-section" data-section>
+          <h2>Guides & playbooks</h2>
+          <div class="res-guide-list" id="res-guides-list"></div>
+        </section>
+
+        <section id="res-faqs" class="res-section" data-section>
+          <h2>FAQs</h2>
+          <div class="res-faqs" id="res-faqs-list"></div>
+        </section>
+      </div>
+
+      <aside class="res-sidebar">
+        <section class="res-panel">
+          <h2>Quick links</h2>
+          <div class="res-quick-links">
+            <a href="#res-calculators">Calculators</a>
+            <a href="#res-generators">Generators</a>
+            <a href="#res-guides">Guides</a>
+            <a href="#res-faqs">FAQs</a>
           </div>
-        </div>
-      </section>
-
-      <div class="divider"></div>
-
-      <section id="faqs" class="section">
-        <h2>FAQs</h2>
-        <dl class="faq" id="faq-list"></dl>
-      </section>
-
-      <div class="divider"></div>
-
-      <section id="videos" class="section">
-        <h2>Videos</h2>
-        <div class="list" id="video-list"></div>
-      </section>
+        </section>
+        <section class="res-panel">
+          <h2>Table of contents</h2>
+          <nav class="res-toc" id="res-toc"></nav>
+        </section>
+        <section class="res-panel">
+          <div class="res-panel-header" style="display:flex;justify-content:space-between;align-items:center;gap:8px;">
+            <h2 style="margin:0">Save for later</h2>
+            <button type="button" class="res-link-button" id="res-clear-saved">Clear</button>
+          </div>
+          <div id="res-saved-list" class="res-saved"></div>
+          <p id="res-saved-empty" class="res-empty">Tap “Save” on any guide to pin it here.</p>
+        </section>
+      </aside>
     </div>
+  </main>
 
-    <aside class="right">
-      <div class="card surface">
-        <h3>Quick links</h3>
-        <div class="row" style="gap:8px;flex-wrap:wrap">
-          <a class="btn btn-ghost btn-small" href="#featured">Featured</a>
-          <a class="btn btn-ghost btn-small" href="#all">All</a>
-          <a class="btn btn-ghost btn-small" href="#calculators">Calculators</a>
-          <a class="btn btn-ghost btn-small" href="#faqs">FAQs</a>
-          <a class="btn btn-ghost btn-small" href="#videos">Videos</a>
-        </div>
-      </div>
-      <div class="card surface" style="margin-top:12px">
-        <h3>Table of contents</h3>
-        <nav class="toc" id="ra-toc"></nav>
-      </div>
-      <div class="card surface" style="margin-top:12px">
-        <h3>My saved</h3>
-        <div id="ra-saved" class="list"></div>
-        <div id="ra-saved-empty" class="empty">Save any item — it will appear here.</div>
-      </div>
-      <div class="card surface" style="margin-top:12px">
-        <h3>Need help?</h3>
-        <p class="muted">Ping us on WhatsApp. We’ll jump in.</p>
-        <a class="btn" href="https://wa.me/61466873332?text=Hi%20C2C%2C%20need%20help%20with%20Resources" target="_blank" rel="noopener">WhatsApp us</a>
-      </div>
-    </aside>
-  </section>
-
-  <div class="floating-top">
-    <button id="ra-top" class="btn btn-primary btn-small">↑ Top</button>
-  </div>
-  <div class="kbd-help">
-    <button id="ra-help" class="btn btn-ghost btn-small">? Shortcuts</button>
-  </div>
-</main>
-
-<script>
-// ------------- Data -------------
-const RA_TAGS = ["template","guide","legal","calculator","checklist","video","faq","integration","pricing","compliance","victoria","australia","pdf","stripe","whatsapp","email","brand","setup"];
-
-const RA_ITEMS = [
-  {id:"tmpl-variation", title:"Variation template (PDF + DOCX)", type:"template", tags:["template","pdf","victoria","australia"], href:"/assets/resources/Variation-Template.pdf", desc:"Lock scope changes before work starts. Ready-to-sign template with space for price and scope.", icon:"T", featured:true, popular:98, added:"2025-09-01"},
-  {id:"tmpl-quote", title:"Quote template (fast reply)", type:"template", tags:["template","pdf"], href:"/assets/resources/Quote-Template.pdf", desc:"Short form quote designed for WhatsApp replies. Converts to signed PDF.", icon:"T", popular:75, added:"2025-09-05"},
-  {id:"tmpl-agreement", title:"Service agreement (plain‑english)", type:"template", tags:["template","pdf","compliance"], href:"/assets/resources/Service-Agreement.pdf", desc:"Keep it simple and enforceable. Includes variation clause language.", icon:"T", popular:64, added:"2025-08-28"},
-  {id:"guide-whatsapp", title:"WhatsApp-first workflow", type:"guide", tags:["guide","whatsapp"], href:"#", desc:"Reply with scope + price → tap Send Variation → signed PDF. Screenshots and tips.", icon:"G", featured:true, popular:81, added:"2025-09-02"},
-  {id:"guide-brand", title:"Brand setup: logos, colours, receipts", type:"guide", tags:["guide","brand","setup"], href:"#", desc:"Add your logo and brand colours across receipts and checkout.", icon:"G", popular:43, added:"2025-08-25"},
-  {id:"legal-vic", title:"Victoria: variation rules snapshot", type:"legal", tags:["legal","victoria","australia","compliance"], href:"#", desc:"Plain-English summary of variation requirements for VIC. Not legal advice.", icon:"L", featured:true, popular:53, added:"2025-08-15"},
-  {id:"legal-au", title:"Australia-wide: signatures & timestamps", type:"legal", tags:["legal","australia","compliance"], href:"#", desc:"What counts as approval, record-keeping, and audit trails.", icon:"L", popular:61, added:"2025-08-12"},
-  {id:"chk-prestart", title:"Pre-start site checklist", type:"checklist", tags:["checklist","victoria"], href:"#", desc:"Quick pre-start punch list to avoid disputes later.", icon:"C", popular:52, added:"2025-08-29"},
-  {id:"calc-gst", title:"GST calculator", type:"calculator", tags:["calculator","pricing","australia"], href:"#calculators", desc:"10% GST maths — totals and reverse.", icon:"Σ", popular:70, added:"2025-09-06"},
-  {id:"calc-variation", title:"Variation quote estimator", type:"calculator", tags:["calculator","pricing"], href:"#calculators", desc:"Materials + labour + markup. Ready in seconds.", icon:"Σ", popular:67, added:"2025-09-06"},
-  {id:"video-overview", title:"Video: C2C in 90 seconds", type:"video", tags:["video"], href:"https://player.vimeo.com/video/0000001", desc:"High-level walk-through with real examples.", icon:"▶", popular:40, added:"2025-08-22"},
-  {id:"video-send", title:"Video: Send a variation", type:"video", tags:["video","whatsapp"], href:"https://player.vimeo.com/video/0000002", desc:"From message to signed PDF, step by step.", icon:"▶", popular:46, added:"2025-08-23"},
-  {id:"faq-billing", title:"Do you charge GST?", type:"faq", tags:["faq","pricing"], href:"#faqs", desc:"Yes, GST applies to AU customers. Stripe receipts show tax breakdown.", icon:"?", popular:33, added:"2025-08-18"},
-  {id:"faq-legal", title:"Are signatures legally valid?", type:"faq", tags:["faq","legal"], href:"#faqs", desc:"Yes — approvals are timestamped; PDFs are immutable and stored.", icon:"?", popular:41, added:"2025-08-18"},
-  {id:"int-stripe", title:"Stripe: Payment Links tips", type:"integration", tags:["integration","stripe","pricing"], href:"#", desc:"Best practices: product names, branding, receipts, refunds.", icon:"S", featured:true, popular:72, added:"2025-08-30"},
-  {id:"int-email", title:"Email receipts: what can be customised", type:"integration", tags:["integration","email","brand"], href:"#", desc:"Colours, logo, support address, and custom domains.", icon:"S", popular:36, added:"2025-08-30"},
-  {id:"tmpl-safety", title:"Basic SWMS template", type:"template", tags:["template","pdf","compliance"], href:"/assets/resources/SWMS-Basic.pdf", desc:"Simple SWMS outline with common risks and controls.", icon:"T", popular:51, added:"2025-08-27"},
-  {id:"guide-disputes", title:"Docs that win disputes", type:"guide", tags:["guide","legal","compliance"], href:"#", desc:"How to build a tidy trail that shuts down arguments.", icon:"G", featured:true, popular:89, added:"2025-09-07"},
-  {id:"chk-handover", title:"Handover checklist", type:"checklist", tags:["checklist"], href:"#", desc:"Final checks and sign-off items to prevent callbacks.", icon:"C", popular:34, added:"2025-08-27"},
-  {id:"tmpl-invoice", title:"Invoice template (GST)", type:"template", tags:["template","pdf","pricing"], href:"/assets/resources/Invoice-Template.pdf", desc:"AUS GST-friendly invoice layout with ABN & line items.", icon:"T", popular:55, added:"2025-08-20"},
-  {id:"guide-comms", title:"Write messages that get 'yes'", type:"guide", tags:["guide","whatsapp"], href:"#", desc:"Prompts and phrasing that move jobs forward fast.", icon:"G", popular:62, added:"2025-08-19"},
-  {id:"legal-records", title:"Record-keeping & retention", type:"legal", tags:["legal","compliance","australia"], href:"#", desc:"How long to keep docs, and where.", icon:"L", popular:27, added:"2025-08-09"},
-  {id:"guide-sameday", title:"Same‑day setup playbook", type:"guide", tags:["guide","setup"], href:"#", desc:"From logo to first signed PDF — same day.", icon:"G", popular:73, added:"2025-09-05"},
-  {id:"faq-cancel", title:"Can I cancel anytime?", type:"faq", tags:["faq","pricing"], href:"#faqs", desc:"Yes. Plans are month‑to‑month; annual has a discount.", icon:"?", popular:29, added:"2025-08-17"},
-  {id:"tmpl-quote-email", title:"Email template: send a quote", type:"template", tags:["template","email"], href:"/assets/resources/Email-Quote.txt", desc:"Copy‑paste email with placeholders for scope and totals.", icon:"T", popular:31, added:"2025-08-28"},
-  {id:"tmpl-variation-wa", title:"WhatsApp text: send a variation", type:"template", tags:["template","whatsapp"], href:"/assets/resources/WA-Variation.txt", desc:"Paste, tweak, send — makes approvals frictionless.", icon:"T", popular:45, added:"2025-09-01"}
-];
-
-const RA_FAQS = [
-  {q:"How do I get a signed PDF?", a:"Reply with scope + price, tap *Send Variation*, client approves, PDF is generated and stored. Time‑stamped, immutable."},
-  {q:"Will this work in Victoria?", a:"Yes. The templates and flows are built for AU — including VIC — and are designed to support clean approvals and tidy trails."},
-  {q:"Can I add my logo?", a:"Yes. Branding (logo and colours) appears on checkout and receipts. Use *Branding → Email receipts / Checkout & Payment Links*."},
-  {q:"Where are my PDFs stored?", a:"Securely in our storage with redundant backups. You can also download and save locally."}
-];
-
-const RA_VIDEOS = [
-  {title:"Overview", url:"https://player.vimeo.com/video/0000001", length:"1:30"},
-  {title:"Send a variation", url:"https://player.vimeo.com/video/0000002", length:"2:10"},
-  {title:"Brand your receipts", url:"https://player.vimeo.com/video/0000003", length:"1:20"}
-];
-
-// ------------- Helpers -------------
-const $ = (sel, root=document) => root.querySelector(sel);
-const $$ = (sel, root=document) => Array.from(root.querySelectorAll(sel));
-const fmtA = n => 'A$'+n.toFixed(2);
-
-function uniqueTags(items){ const s=new Set(); items.forEach(r=>r.tags.forEach(t=>s.add(t))); return Array.from(s).sort(); }
-function parseQS(){ const p=new URLSearchParams(location.search); return { q:p.get('q')||'', tag:p.get('tag')||'', sort:p.get('sort')||'new' }; }
-function updateQS(state){ const p=new URLSearchParams(); if(state.q) p.set('q', state.q); if(state.tag) p.set('tag', state.tag); if(state.sort!=='new') p.set('sort', state.sort); history.replaceState(null,'','?'+p.toString()); }
-
-function cardHTML(r){
-  const tagHTML = r.tags.map(t=>`<span class="chip" data-chip="${t}">${t}</span>`).join(' ');
-  const save = isSaved(r.id);
-  return `<article class="card resource-card" data-id="${r.id}" data-type="${r.type}" data-tags="${r.tags.join(',')}">
-    <div class="icon">${r.icon||'R'}</div>
-    <div>
-      <h3 class="title">${r.title}</h3>
-      <p class="muted" style="margin:0">${r.desc}</p>
-      <div class="meta">${tagHTML}</div>
-      <div class="actions">
-        ${r.href ? `<a class="btn btn-primary btn-small" href="${r.href}" target="${r.href.startsWith('http')? '_blank' : '_self'}" rel="noopener">Open</a>` : ''}
-        <button class="btn btn-ghost btn-small ra-copy" data-id="${r.id}">Copy link</button>
-        <button class="btn btn-ghost btn-small ra-save" data-id="${r.id}">${save?'★ Saved':'☆ Save'}</button>
-      </div>
+  <footer class="res-footer">
+    <div class="res-footer-inner">
+      <span>© C2C Variations</span>
+      <nav class="res-footer-links" aria-label="Footer">
+        <a href="./pricing.html">Pricing</a>
+        <a href="./about.html">About</a>
+        <a href="./resources.html" aria-current="page">Resources</a>
+        <a href="./testimonials.html">Testimonials</a>
+        <a href="./partners.html">Partners</a>
+        <a href="./privacy.html">Privacy</a>
+        <a href="./terms.html">Terms</a>
+      </nav>
     </div>
-  </article>`;
-}
+  </footer>
 
-function renderList(listEl, items){
-  listEl.innerHTML = items.map(cardHTML).join('');
-}
+  <div id="c2c-chat-overlay" hidden></div>
+  <div id="c2c-chatbot-container" hidden role="dialog" aria-modal="true" aria-label="C2C Chat">
+    <header class="c2c-chat-header">
+      <strong>C2C Chat</strong>
+      <button type="button" class="c2c-chat-close" aria-label="Close chat">✕</button>
+    </header>
+    <div class="c2c-chat-body">
+      <p class="c2c-chat-intro">👋 Live chat is being switched on. Ping us on WhatsApp or email and we’ll jump in.</p>
+      <p>
+        <a class="c2c-chat-link" href="https://wa.me/61466873332?text=Hi%20C2C%2C%20keen%20to%20get%20set%20up." target="_blank" rel="noopener">Chat on WhatsApp</a><br>
+        <a class="c2c-chat-link" href="mailto:info@c2cvariations.com.au">info@c2cvariations.com.au</a>
+      </p>
+    </div>
+  </div>
 
-function searchItems(q, tag, sort){
-  q = (q||'').toLowerCase().trim();
-  let arr = RA_ITEMS.slice();
-  if(q){
-    arr = arr.filter(r => (r.title+' '+r.desc+' '+r.tags.join(' ')).toLowerCase().includes(q));
-  }
-  if(tag){
-    arr = arr.filter(r => r.tags.includes(tag));
-  }
-  if(sort==='az'){ arr.sort((a,b)=>a.title.localeCompare(b.title)); }
-  else if(sort==='popular'){ arr.sort((a,b)=>b.popular-a.popular); }
-  else { // new
-    arr.sort((a,b)=> (b.added||'').localeCompare(a.added||''));
-  }
-  return arr;
-}
+  <script>
+  (function(){
+    const currency = (value) => 'A$' + value.toFixed(2);
 
-// saved list
-function getSaved(){ try{ return JSON.parse(localStorage.getItem('ra_saved')||'[]'); }catch(e){ return []; } }
-function setSaved(ids){ localStorage.setItem('ra_saved', JSON.stringify(ids)); }
-function isSaved(id){ return getSaved().includes(id); }
-function toggleSaved(id){
-  let s=getSaved();
-  if(s.includes(id)){ s = s.filter(x=>x!==id); }
-  else{ s.push(id); }
-  setSaved(s); renderSaved();
-}
-function renderSaved(){
-  const s = getSaved();
-  const wrap = $('#ra-saved');
-  const empty = $('#ra-saved-empty');
-  if(!s.length){ wrap.innerHTML=''; empty.style.display='block'; return; }
-  empty.style.display='none';
-  renderList(wrap, RA_ITEMS.filter(r=>s.includes(r.id)));
-}
+    const guides = [
+      { id: 'guide-setup', title: 'Same-day setup playbook', summary: 'From WhatsApp message to signed PDF in a single shift.', tag: 'Coming soon' },
+      { id: 'guide-claim', title: 'Claim intake checklist', summary: 'Capture scope, evidence and approvals before crews roll.', tag: 'Drafting' },
+      { id: 'guide-compliance', title: 'VIC plumbing compliance snapshot', summary: 'Paperwork, timelines and storage obligations.', tag: 'Research' }
+    ];
 
-function buildToc(){
-  const toc = $('#ra-toc');
-  const sec = ['featured','all','calculators','faqs','videos'];
-  toc.innerHTML = sec.map(id=>`<a href="#${id}" data-toc="${id}">${id[0].toUpperCase()+id.slice(1)}</a>`).join('');
-  function update(){
-    let active = sec[0];
-    for(const id of sec){
-      const el = document.getElementById(id);
-      const rect = el.getBoundingClientRect();
-      if(rect.top < 120) active = id;
+    const faqs = [
+      { q: 'Do I need a new app to use this?', a: 'No — C2C lives in WhatsApp. The guides show how to capture approvals without switching tools.' },
+      { q: 'Can I download the generated text?', a: 'Yes. Use the download buttons in each generator to grab a ready-to-edit TXT file.' },
+      { q: 'Will these templates work outside Victoria?', a: 'Most guides are national, but we flag VIC-specific compliance where it matters.' }
+    ];
+
+    const toc = [
+      { id: 'res-calculators', label: 'Calculators' },
+      { id: 'res-generators', label: 'Generators' },
+      { id: 'res-guides', label: 'Guides' },
+      { id: 'res-faqs', label: 'FAQs' }
+    ];
+
+    const savedKey = 'c2c_resource_saved';
+
+    const tocNav = document.getElementById('res-toc');
+    tocNav.innerHTML = toc.map(item => `<a href="#${item.id}" data-toc="${item.id}">${item.label}</a>`).join('');
+
+    function highlightTOC(entries){
+      entries.forEach(entry => {
+        if(entry.isIntersecting){
+          const active = entry.target.id;
+          tocNav.querySelectorAll('a').forEach(link => {
+            link.classList.toggle('active', link.getAttribute('data-toc') === active);
+          });
+        }
+      });
     }
-    $$('#ra-toc a').forEach(a=>a.classList.toggle('active', a.getAttribute('data-toc')===active));
-  }
-  document.addEventListener('scroll', update, {passive:true});
-  update();
-}
 
-// ------------- Init -------------
-(function init(){
-  // Filters (chips)
-  const tags = uniqueTags(RA_ITEMS.concat(RA_TAGS.map(t=>({tags:[t]}))));
-  const filterWrap = $('#ra-filters');
-  filterWrap.innerHTML = tags.map(t=>`<span class="chip" data-filter="${t}">${t}</span>`).join('');
-  filterWrap.addEventListener('click', (e)=>{
-    const chip = e.target.closest('[data-filter]'); if(!chip) return;
-    const tag = chip.getAttribute('data-filter');
-    if(state.tag===tag){ state.tag=''; } else { state.tag = tag; }
-    update();
-  });
+    const observer = new IntersectionObserver(highlightTOC, { rootMargin: '-40% 0px -55% 0px', threshold: [0, 0.5, 1] });
+    toc.forEach(item => {
+      const section = document.getElementById(item.id);
+      if(section){ observer.observe(section); }
+    });
 
-  // Featured
-  renderList($('#ra-featured'), RA_ITEMS.filter(r=>r.featured));
+    // Calculators
+    const gstBase = document.getElementById('res-gst-base');
+    const gstTotal = document.getElementById('res-gst-total');
+    const gstOut = document.getElementById('res-gst-output');
+    document.querySelectorAll('[data-gst]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const mode = btn.getAttribute('data-gst');
+        if(mode === 'from-base'){
+          const base = parseFloat(gstBase.value || '0');
+          const gst = base * 0.10;
+          const total = base + gst;
+          gstTotal.value = total.toFixed(2);
+          gstOut.textContent = `GST: ${currency(gst)} • Total: ${currency(total)}`;
+        } else {
+          const total = parseFloat(gstTotal.value || '0');
+          const base = total / 1.10;
+          const gst = total - base;
+          gstBase.value = base.toFixed(2);
+          gstOut.textContent = `GST: ${currency(gst)} • Ex GST: ${currency(base)}`;
+        }
+      });
+    });
 
-  // All
-  const qs = parseQS();
-  const stateDefault = { q: qs.q, tag: qs.tag, sort: qs.sort };
-  window.state = stateDefault;
+    document.getElementById('res-day-calc').addEventListener('click', () => {
+      const hours = parseFloat(document.getElementById('res-day-hours').value || '0');
+      const rate = parseFloat(document.getElementById('res-day-rate').value || '0');
+      const dayRate = hours * rate;
+      document.getElementById('res-day-output').textContent = `Day rate: ${currency(dayRate)}`;
+    });
 
-  const search = $('#ra-search');
-  const sort = $('#ra-sort');
-  search.value = state.q;
-  sort.value = state.sort;
+    document.getElementById('res-var-calc').addEventListener('click', () => {
+      const materials = parseFloat(document.getElementById('res-var-materials').value || '0');
+      const hours = parseFloat(document.getElementById('res-var-hours').value || '0');
+      const rate = parseFloat(document.getElementById('res-var-rate').value || '0');
+      const markup = parseFloat(document.getElementById('res-var-markup').value || '0') / 100;
+      const labour = hours * rate;
+      const subtotal = materials + labour;
+      const quote = subtotal * (1 + markup);
+      document.getElementById('res-var-output').textContent = `Quote: ${currency(quote)} (ex GST)`;
+    });
 
-  function doSearch(){ renderList($('#ra-results'), searchItems(state.q, state.tag, state.sort)); }
-  function markFilter(){ $$('#ra-filters .chip').forEach(c=>c.classList.toggle('active', c.getAttribute('data-filter')===state.tag)); }
+    // Generators
+    const generators = {
+      claim: {
+        filename(data){
+          const slug = (data.client || 'claim').toLowerCase().replace(/[^a-z0-9]+/g,'-');
+          return `claim-intake-${slug || 'draft'}.txt`;
+        },
+        template(data){
+          return `Claim Intake\nClient: ${data.client}\nJob address: ${data.address}\nContact: ${data.contact || 'n/a'}\n\nIssue\n${data.issue}\n\nCaptured via C2C.`;
+        }
+      },
+      variation: {
+        filename(data){
+          const slug = (data.client || 'variation').toLowerCase().replace(/[^a-z0-9]+/g,'-');
+          return `variation-agreement-${slug || 'draft'}.txt`;
+        },
+        template(data){
+          const amount = parseFloat(data.amount || '0');
+          return `Variation Agreement\nClient: ${data.client}\nAmount: ${currency(amount)}\nCompletion date: ${data.date || 'TBC'}\n\nVariation details\n${data.details}\n\nPlease reply APPROVED to lock scope.`;
+        }
+      },
+      vic: {
+        filename(data){
+          const slug = (data.address || 'compliance').toLowerCase().replace(/[^a-z0-9]+/g,'-');
+          return `vic-compliance-${slug || 'draft'}.txt`;
+        },
+        template(data){
+          return `VIC Plumbing Compliance\nLicence: ${data.licence}\nSite: ${data.address}\nCompleted: ${data.date || 'TBC'}\n\nSummary\n${data.notes}\n\nKeep this on file with your compliance certificates.`;
+        }
+      }
+    };
 
-  window.update = function(){
-    updateQS(state);
-    search.value = state.q; sort.value = state.sort;
-    doSearch(); markFilter(); renderSaved();
-  }
+    document.querySelectorAll('.res-generator').forEach(form => {
+      const previewEl = form.querySelector('.res-preview');
+      const downloadBtn = form.querySelector('[data-action="download"]');
+      const type = form.getAttribute('data-generator');
+      const config = generators[type];
+      let lastContent = '';
 
-  update();
+      form.addEventListener('click', (event) => {
+        const action = event.target.getAttribute('data-action');
+        if(!action) return;
+        event.preventDefault();
+        const data = Object.fromEntries(new FormData(form).entries());
+        if(action === 'preview'){
+          if(!config) return;
+          try {
+            lastContent = config.template(data);
+            previewEl.textContent = lastContent;
+            downloadBtn.disabled = false;
+          } catch(err){
+            previewEl.textContent = 'Unable to build preview — check your inputs.';
+            downloadBtn.disabled = true;
+          }
+        }
+        if(action === 'download'){
+          if(!lastContent){
+            previewEl.textContent = 'Generate a preview first.';
+            return;
+          }
+          const blob = new Blob([lastContent], { type: 'text/plain' });
+          const a = document.createElement('a');
+          a.href = URL.createObjectURL(blob);
+          a.download = config ? config.filename(data) : 'generator-output.txt';
+          document.body.appendChild(a);
+          a.click();
+          setTimeout(() => {
+            URL.revokeObjectURL(a.href);
+            a.remove();
+          }, 100);
+        }
+      });
+    });
 
-  // events
-  search.addEventListener('input', ()=>{ state.q = search.value; doSearch(); });
-  sort.addEventListener('change', ()=>{ state.sort = sort.value; doSearch(); });
-  $('#ra-clear').addEventListener('click', ()=>{ state = { q:'', tag:'', sort:'new' }; update(); });
+    // Guides & saves
+    const guidesWrap = document.getElementById('res-guides-list');
+    const savedList = document.getElementById('res-saved-list');
+    const savedEmpty = document.getElementById('res-saved-empty');
+    const clearBtn = document.getElementById('res-clear-saved');
 
-  // copy + save
-  document.addEventListener('click', (e)=>{
-    const copyBtn = e.target.closest('.ra-copy');
-    const saveBtn = e.target.closest('.ra-save');
-    if(copyBtn){
-      const id = copyBtn.getAttribute('data-id');
-      const url = location.origin + location.pathname + '?' + new URLSearchParams({ q: '', tag:'', sort:'new' }).toString() + '#'+id;
-      navigator.clipboard.writeText(url).then(()=>{ copyBtn.textContent='Copied!'; setTimeout(()=>copyBtn.textContent='Copy link',1200); });
+    function getSaved(){
+      try{ return JSON.parse(localStorage.getItem(savedKey) || '[]'); }
+      catch(e){ return []; }
     }
-    if(saveBtn){
-      const id = saveBtn.getAttribute('data-id');
-      toggleSaved(id);
-      saveBtn.textContent = isSaved(id) ? '★ Saved' : '☆ Save';
+    function setSaved(ids){ localStorage.setItem(savedKey, JSON.stringify(ids)); }
+
+    function renderGuides(){
+      const saved = new Set(getSaved());
+      guidesWrap.innerHTML = guides.map(guide => {
+        const active = saved.has(guide.id);
+        return `<article class="res-guide" data-guide="${guide.id}">
+          <h3>${guide.title}</h3>
+          <p>${guide.summary}</p>
+          <span class="res-tag">${guide.tag}</span>
+          <div class="res-buttons">
+            <button type="button" class="res-btn" data-save="${guide.id}">${active ? '★ Saved' : '☆ Save'}</button>
+          </div>
+        </article>`;
+      }).join('');
     }
-  });
 
-  // calculators
-  $('#gst-calc').addEventListener('click', ()=>{
-    const base = parseFloat($('#gst-base').value||0);
-    const gst = base * 0.10, total = base + gst;
-    $('#gst-out').textContent = `GST: ${fmtA(gst)} • Total: ${fmtA(total)}`;
-  });
-  $('#vq-calc').addEventListener('click', ()=>{
-    const mat = parseFloat($('#vq-mat').value||0);
-    const hrs = parseFloat($('#vq-hours').value||0);
-    const rate = parseFloat($('#vq-rate').value||0);
-    const mu = parseFloat($('#vq-markup').value||0)/100;
-    const labour = hrs*rate;
-    const sub = mat + labour;
-    const quote = sub * (1+mu);
-    $('#vq-out').textContent = `Quote: ${fmtA(quote)} (excl. GST)`;
-  });
-  $('#dr-calc').addEventListener('click', ()=>{
-    const hrs = parseFloat($('#dr-hours').value||0);
-    const rate = parseFloat($('#dr-rate').value||0);
-    const day = hrs*rate;
-    $('#dr-out').textContent = `Day rate: ${fmtA(day)}`;
-  });
+    function renderSaved(){
+      const saved = getSaved();
+      if(!saved.length){
+        savedList.innerHTML = '';
+        savedEmpty.style.display = 'block';
+        return;
+      }
+      savedEmpty.style.display = 'none';
+      savedList.innerHTML = saved.map(id => {
+        const guide = guides.find(g => g.id === id);
+        const label = guide ? guide.title : id;
+        return `<div class="res-saved-item">
+          <span>${label}</span>
+          <button type="button" class="res-link-button" data-remove="${id}">Remove</button>
+        </div>`;
+      }).join('');
+    }
 
-  // FAQ
-  const faqWrap = $('#faq-list');
-  faqWrap.innerHTML = RA_FAQS.map((f,i)=>`<dt data-faq="${i}">${f.q}</dt><dd>${f.a}</dd>`).join('');
-  faqWrap.addEventListener('click',(e)=>{
-    const dt = e.target.closest('dt[data-faq]'); if(!dt) return;
-    const dd = dt.nextElementSibling;
-    dd.style.display = (dd.style.display==='none') ? 'block' : 'none';
-  });
-  // collapse all by default
-  $$('#faq-list dd').forEach(dd=>dd.style.display='none');
+    guidesWrap.addEventListener('click', (event) => {
+      const btn = event.target.closest('[data-save]');
+      if(!btn) return;
+      const id = btn.getAttribute('data-save');
+      const saved = new Set(getSaved());
+      if(saved.has(id)){ saved.delete(id); }
+      else { saved.add(id); }
+      setSaved(Array.from(saved));
+      renderGuides();
+      renderSaved();
+    });
 
-  // Videos
-  const v = $('#video-list');
-  v.innerHTML = RA_VIDEOS.map(x=>`<div class="card"><h3>${x.title} <span class="muted">(${x.length})</span></h3><div class="muted">Embed placeholder — replace URL when ready.</div></div>`).join('');
+    savedList.addEventListener('click', (event) => {
+      const removeBtn = event.target.closest('[data-remove]');
+      if(!removeBtn) return;
+      const id = removeBtn.getAttribute('data-remove');
+      const saved = getSaved().filter(item => item !== id);
+      setSaved(saved);
+      renderGuides();
+      renderSaved();
+    });
 
-  // TOC
-  buildToc();
+    clearBtn.addEventListener('click', () => {
+      localStorage.removeItem(savedKey);
+      renderGuides();
+      renderSaved();
+    });
 
-  // buttons
-  $('#ra-top').addEventListener('click', ()=>window.scrollTo({top:0,behavior:'smooth'}));
-  $('#ra-help').addEventListener('click', ()=>alert(`Keyboard shortcuts:
-  /   Focus search
-  ?   This help
-  Esc Clear search`));
+    renderGuides();
+    renderSaved();
 
-  // shortcuts
-  window.addEventListener('keydown', (e)=>{
-    if(e.key==='/'){ e.preventDefault(); $('#ra-search').focus(); $('#ra-search').select(); }
-    if(e.key==='?'){ e.preventDefault(); $('#ra-help').click(); }
-    if(e.key==='Escape'){ $('#ra-clear').click(); }
-  });
-
-  // Deep-link to item by ID (hash)
-  if(location.hash){
-    const id = location.hash.slice(1);
-    const el = document.querySelector('[data-id="'+id+'"]');
-    if(el) el.scrollIntoView({behavior:'smooth', block:'start'});
-  }
-
-  renderSaved();
-})();
-
-// Export saved as CSV
-$('#ra-save-export').addEventListener('click', ()=>{
-  const ids = getSaved();
-  if(!ids.length){ alert('No saved items yet.'); return; }
-  const rows = [['id','title','type','href']].concat(
-    RA_ITEMS.filter(r=>ids.includes(r.id)).map(r=>[r.id,r.title,r.type,r.href||''])
-  );
-  const csv = rows.map(r=>r.map(x=>`"${String(x).replace(/"/g,'""')}"`).join(',')).join('\n');
-  const blob = new Blob([csv], {type:'text/csv'});
-  const a = Object.assign(document.createElement('a'), {href:URL.createObjectURL(blob), download:'c2c-resources.csv'});
-  document.body.appendChild(a); a.click(); setTimeout(()=>{ URL.revokeObjectURL(a.href); a.remove(); }, 100);
-});
-</script>
+    // FAQs
+    const faqWrap = document.getElementById('res-faqs-list');
+    faqWrap.innerHTML = faqs.map(item => `
+      <details>
+        <summary>${item.q}</summary>
+        <p>${item.a}</p>
+      </details>
+    `).join('');
+  })();
+  </script>
+  <script src="assets/site-nav.js?v=1" defer></script>
+  <script src="assets/chatbot.v6.js?v=1" defer></script>
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -15,6 +15,7 @@
   <meta name="twitter:description" content="Lock scope changes, clear approvals, and time-stamped PDFs. Same-day setup across Australia.">
   <link rel="preload" href="site-mobile.css?v=8" as="style" onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="site-mobile.css?v=8"></noscript>
+  <link rel="stylesheet" href="assets/site-nav.css?v=1">
   <style>
     :root{--bg:#000;--fg:#fff;--muted:#a7a7a7;--card:#0d0d0f;--line:#222;--accent:#ff8a3d;--wa:#25D366;}
     html{-webkit-text-size-adjust:100%;text-size-adjust:100%;}
@@ -39,120 +40,28 @@
   -->
 </head>
 <body>
-<header style="position:sticky;top:0;z-index:50;background:#000;border-bottom:1px solid #222;">
-  <div style="max-width:1100px;margin:0 auto;padding:14px 20px;display:flex;gap:16px;align-items:center;">
-    <a href="/" style="font-weight:800;color:#ff8a3d;text-decoration:none">Home</a>
-    <button class="nav-hamburger" id="nav-hamburger" aria-label="Open navigation" aria-controls="main-nav" aria-expanded="false" tabindex="0" style="margin-left:auto;">
+<header class="site-header" data-nav-root>
+  <div class="container nav-row">
+    <a class="brand" href="./index.html" aria-label="C2C Variations home">
+      <img class="icon" src="./assets/logo-icon.jpg" alt="C2C icon">
+    </a>
+    <button class="nav-hamburger" type="button" data-nav-toggle aria-controls="main-nav" aria-expanded="false" aria-label="Open navigation">
       <span class="nav-hamburger-bar"></span>
       <span class="nav-hamburger-bar"></span>
       <span class="nav-hamburger-bar"></span>
     </button>
-    <nav id="main-nav" style="display:flex;gap:16px;margin-left:auto" role="navigation" aria-label="Main">
-      <a href="/pricing" style="color:#ff8a3d;text-decoration:none">Pricing</a>
-      <a href="/docs" style="color:#ff8a3d;text-decoration:none">Docs</a>
-      <a href="/about" style="color:#ff8a3d;text-decoration:none">About</a>
-      <a href="/privacy" style="color:#ff8a3d;text-decoration:none">Privacy</a>
-      <a href="/terms" style="color:#ff8a3d;text-decoration:none">Terms</a>
+    <nav class="nav site-nav" id="main-nav" role="navigation" aria-label="Main" data-nav-menu>
+      <a href="./index.html">Home</a>
+      <a href="./pricing.html">Pricing</a>
+      <a href="./about.html">About</a>
+      <a href="./docs.html">Docs</a>
+        <a href="./resources.html">Resources</a>
       <a class="btn btn-wa" href="https://wa.me/61466873332?text=Hi%20C2C%2C%20keen%20to%20get%20set%20up.&utm_source=site&utm_medium=button&utm_campaign=whatsapp" target="_blank" rel="noopener">WhatsApp</a>
-      <button id="c2c-chat-cta" class="c2c-chat-cta" aria-controls="c2c-chatbot-container" aria-expanded="false">💬 Chat with C2C</button>
+      <button type="button" id="c2c-chat-cta" class="c2c-chat-cta" aria-controls="c2c-chatbot-container" aria-expanded="false">💬 Chat with C2C</button>
     </nav>
   </div>
-  <style>
-    .nav-hamburger {
-      display: none;
-      flex-direction: column;
-      justify-content: center;
-      align-items: center;
-      width: 44px;
-      height: 44px;
-      background: none;
-      border: none;
-      cursor: pointer;
-      z-index: 100;
-      margin-left: 8px;
-    }
-    .nav-hamburger-bar {
-      width: 28px;
-      height: 4px;
-      background: #fff;
-      border-radius: 2px;
-      margin: 3px 0;
-      transition: all 0.3s;
-      display: block;
-    }
-    @media (max-width: 768px) {
-      .nav-hamburger { display: flex !important; }
-      #main-nav {
-        position: absolute;
-        top: 64px;
-        right: 0;
-        left: 0;
-        background: rgba(0,0,0,0.98);
-        flex-direction: column !important;
-        align-items: flex-start !important;
-        gap: 0 !important;
-        padding: 0 0 12px 0 !important;
-        box-shadow: 0 8px 24px rgba(0,0,0,0.18);
-        border-bottom: 1px solid #222;
-        z-index: 99;
-        transform: translateY(-120%);
-        opacity: 0;
-        pointer-events: none;
-        transition: transform 0.25s, opacity 0.25s;
-      }
-      #main-nav.open {
-        transform: translateY(0);
-        opacity: 1;
-        pointer-events: auto;
-      }
-      #main-nav a, #main-nav .btn, #main-nav #c2c-chat-cta {
-        width: 100%;
-        text-align: left;
-        padding: 14px 24px;
-        border-radius: 0;
-        font-size: 1.1rem;
-        border: none;
-        background: none;
-        margin: 0;
-        box-shadow: none;
-      }
-      #main-nav .btn, #main-nav #c2c-chat-cta {
-        margin-top: 6px;
-      }
-    }
-  </style>
-  <script>
-    (function(){
-      var hamburger = document.getElementById('nav-hamburger');
-      var nav = document.getElementById('main-nav');
-      if (!hamburger || !nav) return;
-      hamburger.addEventListener('click', function(){
-        var open = nav.classList.toggle('open');
-        hamburger.setAttribute('aria-expanded', open);
-      });
-      nav.addEventListener('click', function(e){
-        if(e.target.tagName==='A'||e.target.classList.contains('btn')||e.target.id==='c2c-chat-cta'){
-          nav.classList.remove('open');
-          hamburger.setAttribute('aria-expanded','false');
-        }
-      });
-      document.addEventListener('click', function(e){
-        if(window.innerWidth>768) return;
-        if(!nav.classList.contains('open')) return;
-        if(!nav.contains(e.target) && e.target!==hamburger){
-          nav.classList.remove('open');
-          hamburger.setAttribute('aria-expanded','false');
-        }
-      });
-      window.addEventListener('resize', function(){
-        if(window.innerWidth>768){
-          nav.classList.remove('open');
-          hamburger.setAttribute('aria-expanded','false');
-        }
-      });
-    })();
-  </script>
 </header>
+
 
   <div class="wrap">
     <h1>Terms of Service</h1>
@@ -206,7 +115,7 @@
   <footer class="footer">
     <div class="container footer-links-row">
       <span>© C2C Variations</span>
-      <span class="footer-links"><a href="https://www.c2cvariations.com.au/pricing">See plans</a><a href="https://www.c2cvariations.com.au/about">About</a><a href="https://www.c2cvariations.com.au/testimonials">Testimonials</a><a href="https://www.c2cvariations.com.au/partners">Partners</a><a href="https://www.c2cvariations.com.au/privacy">Privacy</a><a href="https://www.c2cvariations.com.au/terms">Terms</a></span>
+      <span class="footer-links"><a href="https://www.c2cvariations.com.au/pricing">See plans</a><a href="https://www.c2cvariations.com.au/about">About</a><a href="https://www.c2cvariations.com.au/resources">Resources</a><a href="https://www.c2cvariations.com.au/testimonials">Testimonials</a><a href="https://www.c2cvariations.com.au/partners">Partners</a><a href="https://www.c2cvariations.com.au/privacy">Privacy</a><a href="https://www.c2cvariations.com.au/terms">Terms</a></span>
     </div>
   <style>
     @media (max-width: 600px) {
@@ -231,8 +140,8 @@
     }
   </style>
   </footer>
+  <script src="assets/site-nav.js?v=1" defer></script>
   <script src="assets/chatbot.v6.js?v=1" defer></script>
-</script>
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/testimonials.html
+++ b/testimonials.html
@@ -16,6 +16,7 @@
   <meta name="twitter:description" content="Lock scope changes, clear approvals, and time-stamped PDFs. Same-day setup across Australia.">
   <link rel="preload" href="site-mobile.css?v=8" as="style" onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="site-mobile.css?v=8"></noscript>
+  <link rel="stylesheet" href="assets/site-nav.css?v=1">
   <link rel="icon" href="./favicon.ico">
   <link rel="apple-touch-icon" href="./apple-touch-icon.png">
   <meta name="theme-color" content="#000000">
@@ -86,122 +87,28 @@
   -->
 </head>
 <body>
-  <header class="site-header">
-    <div class="container nav-row">
-      <a class="brand" href="./index.html" aria-label="C2C Variations home">
-        <img class="icon" src="./assets/logo-icon.jpg" alt="C2C icon">
-      </a>
-      <button class="nav-hamburger" id="nav-hamburger" aria-label="Open navigation" aria-controls="main-nav" aria-expanded="false" tabindex="0">
-        <span class="nav-hamburger-bar"></span>
-        <span class="nav-hamburger-bar"></span>
-        <span class="nav-hamburger-bar"></span>
-      </button>
-      <nav class="nav" id="main-nav" role="navigation" aria-label="Main">
-        <a href="./index.html">Home</a>
-        <a href="./pricing.html">Pricing</a>
-        <a href="./about.html">About</a>
-        <a href="./docs.html">Docs</a>
-        <a class="btn btn-wa" href="https://wa.me/61466873332?text=Hi%20C2C%2C%20keen%20to%20get%20set%20up.&utm_source=site&utm_medium=button&utm_campaign=whatsapp" target="_blank" rel="noopener">WhatsApp</a>
-        <button id="c2c-chat-cta" class="c2c-chat-cta" aria-controls="c2c-chatbot-container" aria-expanded="false">💬 Chat with C2C</button>
-      </nav>
-  <style>
-    .nav-hamburger {
-      display: none;
-      flex-direction: column;
-      justify-content: center;
-      align-items: center;
-      width: 44px;
-      height: 44px;
-      background: none;
-      border: none;
-      cursor: pointer;
-      z-index: 100;
-      margin-left: 8px;
-    }
-    .nav-hamburger-bar {
-      width: 28px;
-      height: 4px;
-      background: #fff;
-      border-radius: 2px;
-      margin: 3px 0;
-      transition: all 0.3s;
-      display: block;
-    }
-    @media (max-width: 768px) {
-      .nav-hamburger { display: flex; }
-      .nav-row { gap: 8px; }
-      .nav {
-        position: absolute;
-        top: 64px;
-        right: 0;
-        left: 0;
-        background: rgba(0,0,0,0.98);
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 0;
-        padding: 0 0 12px 0;
-        box-shadow: 0 8px 24px rgba(0,0,0,0.18);
-        border-bottom: 1px solid var(--outline);
-        z-index: 99;
-        transform: translateY(-120%);
-        opacity: 0;
-        pointer-events: none;
-        transition: transform 0.25s, opacity 0.25s;
-      }
-      .nav.open {
-        transform: translateY(0);
-        opacity: 1;
-        pointer-events: auto;
-      }
-      .nav a, .nav .btn, .nav #c2c-chat-cta {
-        width: 100%;
-        text-align: left;
-        padding: 14px 24px;
-        border-radius: 0;
-        font-size: 1.1rem;
-        border: none;
-        background: none;
-        margin: 0;
-        box-shadow: none;
-      }
-      .nav .btn, .nav #c2c-chat-cta {
-        margin-top: 6px;
-      }
-    }
-  </style>
-  <script>
-    (function(){
-      var hamburger = document.getElementById('nav-hamburger');
-      var nav = document.getElementById('main-nav');
-      if (!hamburger || !nav) return;
-      hamburger.addEventListener('click', function(){
-        var open = nav.classList.toggle('open');
-        hamburger.setAttribute('aria-expanded', open);
-      });
-      nav.addEventListener('click', function(e){
-        if(e.target.tagName==='A'||e.target.classList.contains('btn')||e.target.id==='c2c-chat-cta'){
-          nav.classList.remove('open');
-          hamburger.setAttribute('aria-expanded','false');
-        }
-      });
-      document.addEventListener('click', function(e){
-        if(window.innerWidth>768) return;
-        if(!nav.classList.contains('open')) return;
-        if(!nav.contains(e.target) && e.target!==hamburger){
-          nav.classList.remove('open');
-          hamburger.setAttribute('aria-expanded','false');
-        }
-      });
-      window.addEventListener('resize', function(){
-        if(window.innerWidth>768){
-          nav.classList.remove('open');
-          hamburger.setAttribute('aria-expanded','false');
-        }
-      });
-    })();
-  </script>
-    </div>
-  </header>
+  <header class="site-header" data-nav-root>
+  <div class="container nav-row">
+    <a class="brand" href="./index.html" aria-label="C2C Variations home">
+      <img class="icon" src="./assets/logo-icon.jpg" alt="C2C icon">
+    </a>
+    <button class="nav-hamburger" type="button" data-nav-toggle aria-controls="main-nav" aria-expanded="false" aria-label="Open navigation">
+      <span class="nav-hamburger-bar"></span>
+      <span class="nav-hamburger-bar"></span>
+      <span class="nav-hamburger-bar"></span>
+    </button>
+    <nav class="nav site-nav" id="main-nav" role="navigation" aria-label="Main" data-nav-menu>
+      <a href="./index.html">Home</a>
+      <a href="./pricing.html">Pricing</a>
+      <a href="./about.html">About</a>
+      <a href="./docs.html">Docs</a>
+        <a href="./resources.html">Resources</a>
+      <a class="btn btn-wa" href="https://wa.me/61466873332?text=Hi%20C2C%2C%20keen%20to%20get%20set%20up.&utm_source=site&utm_medium=button&utm_campaign=whatsapp" target="_blank" rel="noopener">WhatsApp</a>
+      <button type="button" id="c2c-chat-cta" class="c2c-chat-cta" aria-controls="c2c-chatbot-container" aria-expanded="false">💬 Chat with C2C</button>
+    </nav>
+  </div>
+</header>
+
   <main class="container">
 <a class="link" href="./index.html">← Back to homepage</a>
 <h1>Testimonials</h1>
@@ -217,7 +124,7 @@
   <footer class="footer">
     <div class="container footer-links-row">
       <span>© C2C Variations</span>
-      <span class="footer-links"><a href="https://www.c2cvariations.com.au/pricing">See plans</a><a href="https://www.c2cvariations.com.au/about">About</a><a href="https://www.c2cvariations.com.au/testimonials">Testimonials</a><a href="https://www.c2cvariations.com.au/partners">Partners</a><a href="https://www.c2cvariations.com.au/privacy">Privacy</a><a href="https://www.c2cvariations.com.au/terms">Terms</a></span>
+      <span class="footer-links"><a href="https://www.c2cvariations.com.au/pricing">See plans</a><a href="https://www.c2cvariations.com.au/about">About</a><a href="https://www.c2cvariations.com.au/resources">Resources</a><a href="https://www.c2cvariations.com.au/testimonials" aria-current="page">Testimonials</a><a href="https://www.c2cvariations.com.au/partners">Partners</a><a href="https://www.c2cvariations.com.au/privacy">Privacy</a><a href="https://www.c2cvariations.com.au/terms">Terms</a></span>
     </div>
   <style>
     @media (max-width: 600px) {
@@ -257,8 +164,8 @@
       </p>
     </div>
   </div>
+  <script src="assets/site-nav.js?v=1" defer></script>
   <script src="assets/chatbot.v6.js?v=1" defer></script>
-</script>
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",


### PR DESCRIPTION
## Summary
- refactor every page to share the new responsive header with reliable mobile toggling, outside-click handling, and ticker cleanup
- add capture-phase handlers so all `https://buy.stripe.com` buttons navigate immediately on tap or Enter even when overlays are present
- replace `resources.html` with a self-contained resources hub (calculators, generators, guides/FAQ placeholders, quick links, saved list) and surface the Resources link across header menus and footers

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68ceb8009894832c94c4bf670fa0063d