### PR TITLE
Add Playwright smoke tests for resources.html

### DIFF
--- a/.github/workflows/e2e-manual.yml
+++ b/.github/workflows/e2e-manual.yml
@@ -1,0 +1,33 @@
+name: e2e-manual
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "Base URL (e.g., https://www.c2cvariations.com.au or Pages preview URL)"
+        required: true
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install deps
+        working-directory: qa-e2e
+        run: |
+          npm ci
+          npx playwright install --with-deps
+      - name: Run Playwright tests
+        working-directory: qa-e2e
+        env:
+          BASE_URL: ${{ github.event.inputs.base_url }}
+        run: npx playwright test --reporter=github
+      - name: Upload HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: qa-e2e/playwright-report/
+          if-no-files-found: ignore

--- a/.github/workflows/e2e-prod-nightly.yml
+++ b/.github/workflows/e2e-prod-nightly.yml
@@ -1,0 +1,30 @@
+name: e2e-prod-nightly
+on:
+  schedule:
+    - cron: '0 14 * * *'  # 00:00 AEST daily
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install deps
+        working-directory: qa-e2e
+        run: |
+          npm ci
+          npx playwright install --with-deps
+      - name: Run Playwright against production
+        working-directory: qa-e2e
+        env:
+          BASE_URL: https://www.c2cvariations.com.au
+        run: npx playwright test --reporter=github
+      - name: Upload HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: qa-e2e/playwright-report/
+          if-no-files-found: ignore

--- a/qa-e2e/README.md
+++ b/qa-e2e/README.md
@@ -1,0 +1,17 @@
+# C2C E2E Tests (Playwright)
+
+## What it tests
+- `/resources.html` loads (title/H1, filter visible)
+- Quick shortcuts render; links open in new tabs
+- State/Territory accordions exist
+- Filter works for "uv" and "outage"
+- BOM, Healthdirect, Safe Work Australia, ABCB links present
+- Mobile profiles render
+
+## Run locally
+```bash
+npm ci
+BASE_URL="https://<your-domain>" npm run test:e2e
+# or open UI:
+BASE_URL="https://<your-domain>" npm run test:ui
+```

--- a/qa-e2e/package.json
+++ b/qa-e2e/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "c2c-e2e-tests",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Playwright E2E tests for C2C site (resources.html and basic nav checks).",
+  "scripts": {
+    "test:e2e": "BASE_URL=${BASE_URL:-http://localhost:8788} playwright test --reporter=list",
+    "test:ui": "BASE_URL=${BASE_URL:-http://localhost:8788} playwright test --ui",
+    "postinstall": "playwright install --with-deps"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.47.2"
+  }
+}

--- a/qa-e2e/playwright.config.ts
+++ b/qa-e2e/playwright.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const baseURL = process.env.BASE_URL || 'http://localhost:8788';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  use: {
+    baseURL,
+    trace: 'on-first-retry'
+  },
+  projects: [
+    { name: 'chromium',      use: { ...devices['Desktop Chrome'] } },
+    { name: 'mobile-chrome', use: { ...devices['Pixel 7'] } },
+    { name: 'mobile-safari', use: { ...devices['iPhone 12'] } }
+  ],
+  reporter: [['list']]
+});

--- a/qa-e2e/tests/resources.spec.ts
+++ b/qa-e2e/tests/resources.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '@playwright/test';
+
+const PATH = '/resources.html';
+
+test.describe('Resource Hub – smoke', () => {
+  test('loads and shows main elements', async ({ page }) => {
+    const res = await page.goto(PATH, { waitUntil: 'load' });
+    expect(res?.ok()).toBeTruthy();
+
+    await expect(page).toHaveTitle(/Resource Hub/i);
+    const h1 = page.locator('h1');
+    await expect(h1).toContainText(/Resource Hub|Everything you need on site/i);
+
+    const filter = page.locator('input#filter');
+    await expect(filter).toBeVisible();
+
+    const shortcuts = page.locator('#shortcuts a');
+    const shortcutCount = await shortcuts.count();
+    expect(shortcutCount).toBeGreaterThan(0);
+
+    const target = await shortcuts.first().getAttribute('target');
+    expect(target).toBe('_blank');
+
+    const accordions = page.locator('details.accordion, details[open], details');
+    expect(await accordions.count()).toBeGreaterThan(4);
+  });
+
+  test('filter reduces results and finds UV and outage links', async ({ page }) => {
+    await page.goto(PATH);
+
+    const shortcuts = page.locator('#shortcuts a');
+    const before = await shortcuts.count();
+
+    const filter = page.locator('input#filter');
+    await filter.fill('uv');
+    await page.waitForTimeout(250);
+    const afterUV = await shortcuts.count();
+    expect(afterUV).toBeGreaterThan(0);
+    expect(afterUV).toBeLessThanOrEqual(before);
+
+    await filter.fill('');
+    await page.waitForTimeout(250);
+
+    await filter.fill('outage');
+    await page.waitForTimeout(250);
+
+    // Either appears in shortcuts or inside state sections:
+    const foundInShortcuts = await shortcuts.count();
+    const stateLinks = page.locator('#states a:has-text("Outage"), #states a:has-text("outage")');
+    const foundInStates = await stateLinks.count();
+
+    expect(foundInShortcuts + foundInStates).toBeGreaterThan(0);
+  });
+
+  test('has official sources visible (BOM, Healthdirect, SWA, ABCB)', async ({ page }) => {
+    await page.goto(PATH);
+
+    for (const domain of [
+      'bom.gov.au',
+      'healthdirect.gov.au',
+      'safeworkaustralia.gov.au',
+      'abcb.gov.au'
+    ]) {
+      await expect(page.locator(`a[href*="${domain}"]`).first(), `Missing link for ${domain}`).toBeVisible();
+    }
+  });
+
+  test('mobile layout renders (sanity)', async ({ page }) => {
+    await page.goto(PATH);
+    await expect(page.locator('input#filter')).toBeVisible();
+    await expect(page.locator('nav.nav')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- add a Playwright test suite under qa-e2e/ focused on resources.html coverage across desktop and mobile profiles
- document local execution steps and wire up manual and scheduled GitHub Actions workflows for running the suite against configurable base URLs

## Testing
- npm install *(fails: 403 Forbidden fetching @playwright/test from npm registry in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68cf8de8329c832c9c49d1ab6cff658b