### PR TITLE
Fix HTML prologue and relocate critical override styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,21 +1,3 @@
-</main>
-<style>
-/* CRITICAL OVERRIDE: Desktop grid always wins */
-@media (min-width: 601px) {
-  .cards, .partners, .testimonials, .how {
-    display: grid !important;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)) !important;
-    gap: 16px !important;
-    align-items: initial !important;
-    justify-items: initial !important;
-  }
-  .how {
-    grid-template-columns: 1.1fr .9fr !important;
-    align-items: center !important;
-    margin: 30px 0 !important;
-  }
-}
-</style>
 <!doctype html>
 <html lang="en">
 <head>
@@ -98,6 +80,21 @@
   .footer a{color:#ff8a3d;text-decoration:none}
   
   @media (max-width: 768px){ .ticker-track{ animation-duration:18s !important; } }
+  /* CRITICAL OVERRIDE: Desktop grid always wins */
+  @media (min-width: 601px) {
+    .cards, .partners, .testimonials, .how {
+      display: grid !important;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)) !important;
+      gap: 16px !important;
+      align-items: initial !important;
+      justify-items: initial !important;
+    }
+    .how {
+      grid-template-columns: 1.1fr .9fr !important;
+      align-items: center !important;
+      margin: 30px 0 !important;
+    }
+  }
   </style>
   <link rel="stylesheet" href="assets/chatbot.v6.css?v=1">
 


### PR DESCRIPTION
## Summary
- remove the stray closing tag that appeared before the document doctype in index.html
- move the CRITICAL OVERRIDE media query into the head style block so the document starts with the expected doctype

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cfb5d86d70832c850778af23c2c126